### PR TITLE
(SDK-34) Add macOS platform configs.

### DIFF
--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -1,0 +1,14 @@
+platform "osx-10.11-x86_64" do |plat|
+  plat.servicetype 'launchd'
+  plat.servicedir '/Library/LaunchDaemons'
+  plat.codename "elcapitan"
+
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
+  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
+  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.3.1 pkg-config'
+  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
+  plat.vmpooler_template "osx-1011-x86_64"
+  plat.output_dir File.join("apple", "10.11", "PC1", "x86_64")
+end

--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -1,0 +1,18 @@
+platform "osx-10.12-x86_64" do |plat|
+  plat.servicetype 'launchd'
+  plat.servicedir '/Library/LaunchDaemons'
+  plat.codename "sierra"
+
+  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
+  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
+  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
+  plat.provision_with '/usr/local/bin/osx-deps pkg-config'
+  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
+  plat.vmpooler_template "osx-1012-x86_64"
+  plat.output_dir File.join("apple", "10.12", "PC1", "x86_64")
+end


### PR DESCRIPTION
Copied from `puppet-agent` repo, they seem to work without modification.