### PR TITLE
(SDK-215) Add gettext-setup and deps to package.

### DIFF
--- a/configs/components/rubygem-childprocess.rb
+++ b/configs/components/rubygem-childprocess.rb
@@ -3,17 +3,10 @@ component "rubygem-childprocess" do |pkg, settings, platform|
   pkg.md5sum "b0d728c5ead77c9488a42db50a62446b"
   pkg.url "http://buildsources.delivery.puppetlabs.net/childprocess-#{pkg.get_version}.gem"
 
-  pkg.build_requires "ruby-2.1.9"
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH", [
-      "$(shell cygpath -u #{settings[:gcc_bindir]})",
-      "$(shell cygpath -u #{settings[:ruby_bindir]})",
-      "$(shell cygpath -u #{settings[:bindir]})",
-      "/cygdrive/c/Windows/system32",
-      "/cygdrive/c/Windows",
-      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
-    ].join(':')
+    pkg.environment "PATH", settings[:gem_path_env]
   end
 
   pkg.install do

--- a/configs/components/rubygem-colored.rb
+++ b/configs/components/rubygem-colored.rb
@@ -4,17 +4,10 @@ component "rubygem-colored" do |pkg, settings, platform|
   pkg.md5sum "1b1a0f16f7c6ab57d1a2d6de53b13c42"
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}.gem"
 
-  pkg.build_requires "ruby-2.1.9"
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH", [
-      "$(shell cygpath -u #{settings[:gcc_bindir]})",
-      "$(shell cygpath -u #{settings[:ruby_bindir]})",
-      "$(shell cygpath -u #{settings[:bindir]})",
-      "/cygdrive/c/Windows/system32",
-      "/cygdrive/c/Windows",
-      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
-    ].join(':')
+    pkg.environment "PATH", settings[:gem_path_env]
   end
 
   pkg.install do

--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -3,17 +3,10 @@ component "rubygem-cri" do |pkg, settings, platform|
   pkg.md5sum "21438cdbbc0304ffdd20022ae73c671c"
   pkg.url "http://buildsources.delivery.puppetlabs.net/cri-#{pkg.get_version}.gem"
 
-  pkg.build_requires "ruby-2.1.9"
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH", [
-      "$(shell cygpath -u #{settings[:gcc_bindir]})",
-      "$(shell cygpath -u #{settings[:ruby_bindir]})",
-      "$(shell cygpath -u #{settings[:bindir]})",
-      "/cygdrive/c/Windows/system32",
-      "/cygdrive/c/Windows",
-      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
-    ].join(':')
+    pkg.environment "PATH", settings[:gem_path_env]
   end
 
   pkg.install do

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,0 +1,15 @@
+component "rubygem-fast_gettext" do |pkg, settings, platform|
+  pkg.version "1.1.0"
+  pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/fast_gettext-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} fast_gettext-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -4,20 +4,13 @@ component "rubygem-ffi" do |pkg, settings, platform|
   pkg.md5sum "37284a51e5464443f7122b388329a2a0"
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}.gem"
 
-  pkg.build_requires "ruby-2.1.9"
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
     pkg.md5sum "664afc6a316dd648f497fbda3be87137"
     pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
 
-    pkg.environment "PATH", [
-      "$(shell cygpath -u #{settings[:gcc_bindir]})",
-      "$(shell cygpath -u #{settings[:bindir]})",
-      "$(shell cygpath -u #{settings[:ruby_bindir]})",
-      "/cygdrive/c/Windows/system32",
-      "/cygdrive/c/Windows",
-      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
-    ].join(':')
+    pkg.environment "PATH", settings[:gem_path_env]
 
     pkg.install do
       ["#{settings[:gem_install]} ffi-#{pkg.get_version}-x64-mingw32.gem"]

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,0 +1,15 @@
+component "rubygem-gettext-setup" do |pkg, settings, platform|
+  pkg.version "0.24"
+  pkg.md5sum "f766a5e12bbad9f85905638c500e08f6"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/gettext-setup-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} gettext-setup-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -1,0 +1,15 @@
+component "rubygem-gettext" do |pkg, settings, platform|
+  pkg.version "3.2.2"
+  pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/gettext-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} gettext-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -1,0 +1,15 @@
+component "rubygem-locale" do |pkg, settings, platform|
+  pkg.version "2.1.2"
+  pkg.md5sum "def1e89d1d3126a0c684d3b7b20d88d4"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/locale-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} locale-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/components/rubygem-pdk.json
+++ b/configs/components/rubygem-pdk.json
@@ -1,4 +1,4 @@
 {
-  "ref": "c095564a73a731627a7cd84bb90c9d536abe74ae",
+  "ref": "b6c0f2fe16db0b92e2f7e767f6a4652ac7e2701d",
   "url": "git@github.com:puppetlabs/pdk"
 }

--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -3,17 +3,10 @@ component "rubygem-pdk" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/rubygem-pdk.json')
   pkg.version "0.1.0"
 
-  pkg.build_requires "ruby-2.1.9"
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH", [
-      "$(shell cygpath -u #{settings[:gcc_bindir]})",
-      "$(shell cygpath -u #{settings[:ruby_bindir]})",
-      "$(shell cygpath -u #{settings[:bindir]})",
-      "/cygdrive/c/Windows/system32",
-      "/cygdrive/c/Windows",
-      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
-    ].join(':')
+    pkg.environment "PATH", settings[:gem_path_env]
   end
 
   pkg.install do

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -1,0 +1,15 @@
+component "rubygem-text" do |pkg, settings, platform|
+  pkg.version "1.3.1"
+  pkg.md5sum "514c3d1db7a955fe793fc0cb149c164f"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/text-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} text-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -9,6 +9,13 @@ component "runtime" do |pkg, settings, platform|
     # Ruby needs zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
     pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
+
+    # gdbm, yaml-cpp and iconv are all runtime dependancies of ruby, and their libraries need
+    # To exist inside our vendored ruby
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
   elsif platform.is_macos?
 
     # Do nothing

--- a/configs/projects/puppet-sdk.rb
+++ b/configs/projects/puppet-sdk.rb
@@ -116,6 +116,16 @@ project "puppet-sdk" do |proj|
     proj.setting(:cflags, "#{proj.cppflags}")
     proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+
+    proj.setting(:gem_path_env, [
+      "$(shell cygpath -u #{settings[:gcc_bindir]})",
+      "$(shell cygpath -u #{settings[:ruby_bindir]})",
+      "$(shell cygpath -u #{settings[:bindir]})",
+      "/cygdrive/c/Windows/system32",
+      "/cygdrive/c/Windows",
+      "/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0",
+      "$(PATH)",
+    ].join(':'))
   end
 
   if platform.is_macos?
@@ -149,6 +159,13 @@ project "puppet-sdk" do |proj|
   # Childprocess and deps
   proj.component "rubygem-ffi"
   proj.component "rubygem-childprocess"
+
+  # Gettext-setup and deps
+  proj.component "rubygem-locale"
+  proj.component "rubygem-text"
+  proj.component "rubygem-gettext"
+  proj.component "rubygem-fast_gettext"
+  proj.component "rubygem-gettext-setup"
 
   # PDK
   proj.component "rubygem-pdk"


### PR DESCRIPTION
This PR adds the various `gettext` related gems to the puppet-sdk package.

It also de-duplicates a bunch of Windows-specific `PATH` setting and fixes an issue where a few Windows-specific DLL files were not being copied into the Ruby load path during packaging.