### PR TITLE
(maint) fix MSI creation

### DIFF
--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -15,8 +15,6 @@
     <DirectoryRef Id='TARGETDIR'>
       <Directory Id='ProgramMenuFolder'>
         <Directory Id='PuppetSDKShortcutDir' Name="<%= settings[:shortcut_name] %>">
-          <Directory Id='PuppetSDKShortcutDocumentationDir' Name="Documentation">
-          </Directory>
         </Directory>
       </Directory>
     </DirectoryRef>
@@ -25,7 +23,7 @@
       <Component
         Id="PuppetSDKDocumentationShortcuts"
         Guid="616ECAD8-52E7-4DA2-A60C-DE6F11A90E16"
-        Directory="PuppetSDKShortcutDocumentationDir"
+        Directory="PuppetSDKShortcutDir"
         Win64="<%= settings[:win64] %>">
         <IniFile
           Id="PuppetSDKSupportURL"
@@ -36,7 +34,7 @@
           Value="<%= settings[:links][:HelpLink] %>"
           Directory="PuppetSDKShortcutDocumentationDir" />
         <RemoveFolder
-          Id="PuppetSDKShortcutDocumentationDir"
+          Id="PuppetSDKShortcutDir"
           On="uninstall"/>
         <RegistryValue
           Root="HKCU"


### PR DESCRIPTION
Following up on #14, which caused

```
C:\cygwin64\var\tmp\tmp.5fNhzaHOAS\wix\shortcuts.wxs(17) : error LGHT0204 : ICE64: The directory PuppetSDKShortcutDir is in the user profile but is not listed in the RemoveFile table.
```

this removes an additional level of directory, and takes care of proper cleanup of what remains.