### PR TITLE
(FIXUP) Revert updating rubygems to latest

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -150,15 +150,4 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.directory settings[:ruby_dir]
     pkg.directory settings[:ruby_bindir]
   end
-
-  if platform.is_windows?
-    gem_bin = "gem.bat"
-  else
-    gem_bin = "gem"
-  end
-
-  # Update to latest version of rubygems
-  pkg.install do
-    "#{settings[:ruby_bindir]}/#{gem_bin} update --system --no-document"
-  end
 end


### PR DESCRIPTION
We didn't realize there was some magic patching of the rubygems
generated batch wrappers on Windows so updating to a newer version of
rubygems is not trivial. This reverts part of the previous update but
retains the placement of an updated SSL CA cert so that Windows hosts
can contact rubygems.org via SSL.