### PR TITLE
(MAINT) Rename packaged VERSION file to PDK_VERSION

### DIFF
--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -96,7 +96,7 @@ project "pdk" do |proj|
 
   proj.description "Puppet Development Kit"
   proj.version_from_git
-  proj.write_version_file File.join(proj.prefix, 'VERSION')
+  proj.write_version_file File.join(proj.prefix, 'PDK_VERSION')
   proj.license "See components"
   proj.vendor "Puppet, Inc. <info@puppet.com>"
   proj.homepage "https://www.puppet.com"


### PR DESCRIPTION
The pdk gem is going to use searching for this file as a way to
determine whether or not it is a package install or gem install, as well
as determining the installation path for package installs, so the
name of the file should be less ambiguous.