### PR TITLE
(maint) Add tty-which rubygem component

### DIFF
--- a/configs/components/rubygem-tty-which.rb
+++ b/configs/components/rubygem-tty-which.rb
@@ -1,0 +1,15 @@
+component "rubygem-tty-which" do |pkg, settings, platform|
+  pkg.version "0.3.0"
+  pkg.md5sum "633a1f4f8c6e15a26cb83e1be0b9f2ce"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-which-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+
+  if platform.is_windows?
+    pkg.environment "PATH", settings[:gem_path_env]
+  end
+
+  pkg.install do
+    "#{settings[:gem_install]} tty-which-#{pkg.get_version}.gem"
+  end
+end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -192,6 +192,7 @@ project "pdk" do |proj|
   proj.component "rubygem-deep_merge"
   proj.component "rubygem-tty-spinner"
   proj.component "rubygem-json_pure"
+  proj.component "rubygem-tty-which"
 
   # Platform specific deps
   proj.component "ansicon" if platform.is_windows?


### PR DESCRIPTION
For puppetlabs/pdk#149. I noticed the other gems all have their URLs set to buildsources.delivery.puppetlabs.net, but I'm not sure of the best way to get a gem added to there