### PR TITLE
(PDK-353) Add pdk to PATH on Linux/macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ gems
 Gemfile.lock
 *.log
 ext/packaging
+ext/build_metadata.json
 pkg

--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -1,0 +1,9 @@
+component "shellpath" do |pkg, settings, platform|
+  if platform.is_macos?
+    pkg.add_source 'file://resources/files/paths.d/50-pdk', sum: '077ceb5e2f71cf733190a61d2fd221fb'
+    pkg.install_file('./50-pdk', '/etc/paths.d/50-pdk')
+  elsif platform.is_linux?
+    pkg.add_source "file://resources/files/profile.d/pdk.sh", sum: "b6a51cfe9c7d8e435be4f7866a847d69"
+    pkg.install_file('./pdk.sh', '/etc/profile.d/pdk.sh')
+  end
+end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -203,6 +203,9 @@ project "pdk" do |proj|
   # Batteries included copies of module template and required gems
   proj.component "pdk-module-template"
 
+  # Set up PATH on posix platforms
+  proj.component "shellpath" unless platform.is_windows?
+
   # What to include in package?
   proj.directory proj.install_root
   proj.directory proj.prefix

--- a/resources/files/paths.d/50-pdk
+++ b/resources/files/paths.d/50-pdk
@@ -1,0 +1,1 @@
+/opt/puppetlabs/bin

--- a/resources/files/profile.d/pdk.sh
+++ b/resources/files/profile.d/pdk.sh
@@ -1,0 +1,5 @@
+# Add /opt/puppetlabs/bin to the path for sh compatible users
+
+if ! echo "$PATH" | grep -q /opt/puppetlabs/bin ; then
+  export PATH=$PATH:/opt/puppetlabs/bin
+fi


### PR DESCRIPTION
This adds `/opt/puppetlabs/bin` to the PATH in platform appropriate ways on Linux/macOS.

Have tested this on Xenial so far, plan to test more tomorrow