### PR TITLE
(PDK-356) Don't run ansicon under ConEmu on Windows

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -4,8 +4,12 @@ $env:PATH           = "$($env:DEVKIT_BASEDIR)\bin;%PATH%"
 $env:SSL_CERT_FILE  = "$($env:DEVKIT_BASEDIR)\ssl\cert.pem"
 $env:SSL_CERT_DIR   = "$($env:DEVKIT_BASEDIR)\ssl\certs"
 
-function pdk{
-  &$env:DEVKIT_BASEDIR\private\tools\bin\ansicon.exe $env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\pdk $args
+function pdk {
+  if ($env:ConEmuANSI -eq 'ON') {
+    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\pdk $args
+  } else {
+    &$env:DEVKIT_BASEDIR\private\tools\bin\ansicon.exe $env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\pdk $args
+  }
 }
 
 Export-ModuleMember -Function pdk -Variable *


### PR DESCRIPTION
Since ConEmu supports (or can support) the ANSI control sequences natively, it prohibits usage of `ansicon` so we need to check for the relevant ConEmu environment variable to decide whether or not to run `ansicon`.