### PR TITLE
Revert "(MAINT) Add basic rake task to check for out of date rubygem pins"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,3 @@ gem 'packaging', '~> 0.6', :git => 'https://github.com/puppetlabs/packaging.git'
 gem 'rake', '~> 12.0'
 
 #gem 'rubocop', "~> 0.34.2"
-
-group 'development' do
-  gem 'pry-byebug'
-
-  # Rubygems API client
-  gem 'gems'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -36,39 +36,3 @@ if File.exist?(build_defs_file)
     end
   end
 end
-
-namespace :check do
-  desc "Check rubygems-* components to see if newer versions are available on rubygems.org"
-  task :rubygems do
-    require 'gems'
-
-    Dir.glob("#{RAKE_ROOT}/configs/components/rubygem-*.rb").each do |rubygem_conf|
-      conf = File.read(rubygem_conf)
-      gem_name = /^rubygem-(.*)\.rb$/.match(File.basename(rubygem_conf)).to_a[1]
-
-      unless gem_name
-        $stderr.puts "WARN: Could not determine gem_name for '#{File.basename(rubygem_conf)}', skipping"
-        next
-      end
-
-      # Skip components that are pinned via json file.
-      if conf =~ /load_from_json/
-        $stderr.puts "INFO: '#{gem_name}' is pinned via JSON file, skipping"
-        next
-      end
-
-      pin_version = /\.version[ (]+['"]+([^'"]+)/.match(conf).to_a[1]
-
-      unless pin_version
-        $stderr.puts "WARN: Could not determine pinned version for '#{gem_name}', skipping"
-        next
-      end
-
-      latest = Gems.versions(gem_name).first
-
-      if pin_version != latest['number']
-        puts "#{gem_name} @ #{pin_version} -- #{latest['number']} was released #{latest['created_at']}"
-      end
-    end
-  end
-end


### PR DESCRIPTION
We cannot upload new rubygems to buildsources because the upload script is broken. Since this requires a new gem 'gem' and we cannot upload it, this broke vanagon.