### PR TITLE
(PDK-425) Remove wrong PATH setting in PowerShell module

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -1,6 +1,5 @@
 $env:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 $env:RUBY_DIR       = "$($env:DEVKIT_BASEDIR)\private\ruby\2.1.9"
-$env:PATH           = "$($env:DEVKIT_BASEDIR)\bin;%PATH%"
 $env:SSL_CERT_FILE  = "$($env:DEVKIT_BASEDIR)\ssl\cert.pem"
 $env:SSL_CERT_DIR   = "$($env:DEVKIT_BASEDIR)\ssl\certs"
 


### PR DESCRIPTION
The original assignment is wrong. Since the PowerShell module uses
absolute paths, and the pdk itself does PATH handling internally, this
is not required at all.