### PR TITLE
(PDK-423) Move PDK version string into component JSON

### DIFF
--- a/configs/components/rubygem-pdk.json
+++ b/configs/components/rubygem-pdk.json
@@ -1,4 +1,5 @@
 {
   "ref": "f1dbc6a4feaee7948aa8a4124e8f14cc1d809ea2",
+  "version": "1.1.0.pre",
   "url": "git@github.com:puppetlabs/pdk"
 }

--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -1,7 +1,6 @@
 component "rubygem-pdk" do |pkg, settings, platform|
 	# Set url and ref from json file.
   pkg.load_from_json('configs/components/rubygem-pdk.json')
-  pkg.version "1.1.0.pre"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 


### PR DESCRIPTION
To make automatic promotion more straightforward; move PDK's version string into its component JSON. Then we can promote by just updating JSON.