### PR TITLE
(PDK-426) 8.3 paths for Ruby PowerShell integration

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -1,4 +1,8 @@
+$fso = New-Object -ComObject Scripting.FileSystemObject
+
 $env:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
+# Windows API GetShortPathName requires inline C#, so use COM instead
+$env:DEVKIT_BASEDIR = $fso.GetFolder($env:DEVKIT_BASEDIR).ShortPath
 $env:RUBY_DIR       = "$($env:DEVKIT_BASEDIR)\private\ruby\2.1.9"
 $env:SSL_CERT_FILE  = "$($env:DEVKIT_BASEDIR)\ssl\cert.pem"
 $env:SSL_CERT_DIR   = "$($env:DEVKIT_BASEDIR)\ssl\certs"


### PR DESCRIPTION
- Previously the Ruby runtime path would be a LFN, which Ruby tools tend to have
   difficulty with. For instance, configuring the devkit / compiling native gems may
   fail as a result of the longer paths.

   PowerShell and .NET don't natively have access to the GetShortPathName
   Windows API. Using that API requires inline C# compilation, which is a bit
   heavier than simply calling the COM component FileSystemObject.