### PR TITLE
(PDK-422) Add timers and hitimes licenses

### DIFF
--- a/resources/windows/wix/license/LICENSE.rtf
+++ b/resources/windows/wix/license/LICENSE.rtf
@@ -1,800 +1,816 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf830
-{\fonttbl\f0\fswiss\fcharset0 ArialMT;\f1\fswiss\fcharset0 Helvetica;\f2\fmodern\fcharset0 CourierNewPSMT;
-}
-{\colortbl;\red255\green255\blue255;\red0\green0\blue255;\red57\green57\blue57;}
-{\*\expandedcolortbl;;\csgenericrgb\c0\c0\c100000;\csgenericrgb\c22353\c22353\c22353;}
-\paperw11900\paperh16840\vieww20780\viewh24020\viewkind0
-\deftab720
-\pard\pardeftab720\partightenfactor0
-
-\f0\b\fs28 \cf0 License Summary:
-\b0\fs20 \
-\
-\pard\pardeftab720\li360\fi-360\partightenfactor0
-\cf0 Puppet Development Kit - Apache 2.0 License (Copyright (c) 2017 Puppet, Inc.)\
-Ruby - Ruby License (Copyright (c) Yukihiro Matsumoto)\
-WiX Toolset - Microsoft Reciprocal License (MS-RL)\
-\pard\pardeftab720\partightenfactor0
-
-\f1 \cf0 openssl - Openssl Dual License
-\f0 \
-
-\f1 curl - Curl License
-\f0 \
-
-\f1 ansicon - zlib License\
-git/Git For Windows - GNU General Public License v2\
-bundler - MIT License (Portions copyright (c) 2010 Andre Arko, Portions copyright (c) 2009 Engine Yard)\
-childprocess - MIT License (Copyright (c) 2010-2015 Jari Bakken)\
-colored - MIT License (Copyright (c) 2010 Chris Wanstrath)\
-cri - MIT License (Copyright (c) 2015 Denis Defreyne and contributors)\
-\pard\pardeftab720\partightenfactor0
-
-\f0 \cf0 deep_merge - MIT License (Copyright (c) 2008-2016 Steve Midgley, Daniel DeLeo)\
-equatable - MIT License (Copyright (c) 2012 Piotr Murach)\
-Fast Gettext - MIT License\
-ffi - BSD 3-clause License (Copyright (c) 2008-2016, Ruby FFI project contributors All rights reserved.)\
-gettext-setup - Apache 2.0 License (Copyright (C) 2016 Puppet, Inc.)\
-gettext - Ruby License\
-json_pure - Ruby License\
-locale - Ruby License\
-necromancer - MIT License (Copyright (c) 2014 Piotr Murach)\
-pastel - MIT License (Copyright (c) 2014 Piotr Murach)\
-text - MIT License (Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher)\
-tty-color - MIT License (Copyright (c) 2016 Piotr Murach)\
-tty-cursor - MIT License (Copyright (c) 2015 Piotr Murach)\
-tty-prompt - MIT License (Copyright (c) 2015 Piotr Murach)\
-tty-spinner - MIT License (Copyright (c) 2014 Piotr Murach)\
-wisper - MIT License (Copyright (c) 2013 Kris Leech)\
-\
-\pard\pardeftab720\qc\partightenfactor0
-\cf0 \
-\pard\pardeftab720\partightenfactor0
-
-\f1\b\fs28 \cf0 Apache 2.0
-\f0  License Terms:
-\b0\fs20 \
-\pard\pardeftab720\qc\partightenfactor0
-\cf0 \
-\pard\pardeftab720\partightenfactor0
-\cf0 Apache License\
-Version 2.0, January 2004\
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "http://www.apache.org/licenses/"}}{\fldrslt \cf2 \ul \ulc2 http://www.apache.org/licenses/}}\
-\
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\
-\
-1. Definitions.\
-\
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\
-\
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\
-\
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\
-\
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.\
-\
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation, source, and configuration files.\
-\
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\
-\
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\
-\
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\
-\
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."\
-\
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\
-\
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\
-\
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license plies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\
-\
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\
-\
-      (a) You must give any other recipients of the Work or\
-          Derivative Works a copy of this License; and\
-\
-      (b) You must cause any modified files to carry prominent notices\
-          stating that You changed the files; and\
-\
-      (c) You must retain, in the Source form of any Derivative Works\
-          that You distribute, all copyright, patent, trademark, and\
-          attribution notices from the Source form of the Work,\
-          excluding those notices that do not pertain to any part of\
-          the Derivative Works; and\
-\
-      (d) If the Work includes a "NOTICE" text file as part of its\
-          distribution, then any Derivative Works that You distribute\
-          must include a readable copy of the attribution notices\
-          contained within such NOTICE file, excluding those notices\
-          that do not pertain to any part of the Derivative Works, in\
-          at least one of the following places: within a NOTICE text\
-          file distributed as part of the Derivative Works; within the\
-          Source form or documentation, if provided along with the\
-          Derivative Works; or, within a display generated by the\
-          Derivative Works, if and wherever such third-party notices\
-          normally appear. The contents of the NOTICE file are for\
-          informational purposes only and do not modify the License.\
-          You may add Your own attribution notices within Derivative\
-          Works that You distribute, alongside or as an addendum to the\
-          NOTICE text from the Work, provided that such additional\
-          attribution notices cannot be construed as modifying the\
-          License.\
-\
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\
-\
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\
-\
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\
-\
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\
-\
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\
-\
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\
-\
-END OF TERMS AND CONDITIONS\
-\
-APPENDIX: How to apply the Apache License to your work.\
-\
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.\
-\
-   Copyright [yyyy] [name of copyright owner]\
-\
-   Licensed under the Apache License, Version 2.0 (the "License");\
-   you may not use this file except in compliance with the License.\
-   You may obtain a copy of the License at\
-\
-       {\field{\*\fldinst{HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0"}}{\fldrslt \cf2 \ul \ulc2 http://www.apache.org/licenses/LICENSE-2.0}}\
-\
-   Unless required by applicable law or agreed to in writing, software\
-   distributed under the License is distributed on an "AS IS" BASIS,\
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\
-   implied. See the License for the specific language governing\
-   permissions and limitations under the License.\
-\
-\
-\pard\pardeftab720\partightenfactor0
-
-\b\fs28 \cf0 Ruby License Terms:
-\b0\fs20 \
-\
-Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.co.jp>.\
-You can redistribute it and/or modify it under either the terms of the GPL\
-(see COPYING.txt file), or the conditions below:\
-\
-  1. You may make and give away verbatim copies of the source form of the\
-     software without restriction, provided that you duplicate all of the\
-     original copyright notices and associated disclaimers.\
-\
-  2. You may modify your copy of the software in any way, provided that\
-     you do at least ONE of the following:\
-\
-       a) place your modifications in the Public Domain or otherwise\
-          make them Freely Available, such as by posting said\
-	  modifications to Usenet or an equivalent medium, or by allowing\
-	  the author to include your modifications in the software.\
-\
-       b) use the modified software only within your corporation or\
-          organization.\
-\
-       c) rename any non-standard executables so the names do not conflict\
-	  with standard executables, which must also be provided.\
-\
-       d) make other distribution arrangements with the author.\
-\
-  3. You may distribute the software in object code or executable\
-     form, provided that you do at least ONE of the following:\
-\
-       a) distribute the executables and library files of the software,\
-	  together with instructions (in the manual page or equivalent)\
-	  on where to get the original distribution.\
-\
-       b) accompany the distribution with the machine-readable source of\
-	  the software.\
-\
-       c) give non-standard executables non-standard names, with\
-          instructions on where to get the original software distribution.\
-\
-       d) make other distribution arrangements with the author.\
-\
-  4. You may modify and include the part of the software into any other\
-     software (possibly commercial).  But some files in the distribution\
-     are not written by the author, so that they are not under this terms.\
-\
-     They are gc.c(partly), utils.c(partly), regex.[ch], st.[ch] and some\
-     files under the ./missing directory.  See each file for the copying\
-     condition.\
-\
-  5. The scripts and library files supplied as input to or produced as \
-     output from the software do not automatically fall under the\
-     copyright of the software, but belong to whomever generated them, \
-     and may be sold commercially, and may be aggregated with this\
-     software.\
-\
-  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR\
-     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED\
-     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
-     PURPOSE.\
-\
-
-\b\fs28 Microsoft Reciprocal License (MS-RL)
-\b0\fs20 \
-\
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.\
-\
-1. Definitions\
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.\
-A "contribution" is the original software, or any additions or changes to the software.\
-A "contributor" is any person that distributes its contribution under this license.\
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.\
-\
-2. Grant of Rights\
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.\
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.\
-\
-3. Conditions and Limitations\
-(A) Reciprocal Grants- For any file you distribute that contains code from the software (in source code or binary format), you must provide recipients the source code to that file along with a copy of this license, which license will govern that file. You may license other files that are entirely your own work and do not contain code from the software under any terms you choose.\
-(B) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.\
-(C) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.\
-(D) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.\
-(E) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.\
-(F) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.\
-\pard\pardeftab720\partightenfactor0
-
-\f2 \cf3 \
-\pard\pardeftab720\partightenfactor0
-
-\f0\b\fs28 \cf0 Curl License Terms:
-\b0\fs20 \
-\
-COPYRIGHT AND PERMISSION NOTICE\
-\
-Copyright (c) 1996 - 2016, Daniel Stenberg, daniel@haxx.se, and many contributors, see the THANKS file.\
-\
-All rights reserved.\
-\
-Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\
-Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization of the copyright holder.\
-\
-
-\b\fs28 Openssl Dual License Terms:
-\b0\fs20 \
-\
-LICENSE ISSUES\
-==============\
-\
-The OpenSSL toolkit stays under a dual license, i.e. both the conditions of\
-the OpenSSL License and the original SSLeay license apply to the toolkit.\
-See below for the actual license texts.\
-\
-OpenSSL License\
----------------\
-\
-====================================================================\
-Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.\
-\
-Redistribution and use in source and binary forms, with or without\
-modification, are permitted provided that the following conditions\
-are met:\
-\
-1. Redistributions of source code must retain the above copyright\
-  notice, this list of conditions and the following disclaimer.\
-\
-2. Redistributions in binary form must reproduce the above copyright\
-  notice, this list of conditions and the following disclaimer in\
-  the documentation and/or other materials provided with the\
-  distribution.\
-\
-3. All advertising materials mentioning features or use of this\
-  software must display the following acknowledgment:\
-  "This product includes software developed by the OpenSSL Project\
-  for use in the OpenSSL Toolkit. (http://www.openssl.org/)"\
-\
-4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to\
-  endorse or promote products derived from this software without\
-  prior written permission. For written permission, please contact\
-  openssl-core@openssl.org.\
-\
-5. Products derived from this software may not be called "OpenSSL"\
-  nor may "OpenSSL" appear in their names without prior written\
-  permission of the OpenSSL Project.\
-\
-6. Redistributions of any form whatsoever must retain the following\
-  acknowledgment:\
-  "This product includes software developed by the OpenSSL Project\
-  for use in the OpenSSL Toolkit (http://www.openssl.org/)"\
-\
-THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY\
-EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR\
-ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,\
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED\
-OF THE POSSIBILITY OF SUCH DAMAGE.\
-====================================================================\
-\
-This product includes cryptographic software written by Eric Young\
-(eay@cryptsoft.com).  This product includes software written by Tim\
-Hudson (tjh@cryptsoft.com).\
-\
-
-\b\fs28 Original SSLeay License
-\b0\fs20 \
-\
-Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)\
-All rights reserved.\
-\
-This package is an SSL implementation written\
-by Eric Young (eay@cryptsoft.com).\
-The implementation was written so as to conform with Netscapes SSL.\
-\
-This library is free for commercial and non-commercial use as long as\
-the following conditions are aheared to.  The following conditions\
-apply to all code found in this distribution, be it the RC4, RSA,\
-lhash, DES, etc., code; not just the SSL code.  The SSL documentation\
-included with this distribution is covered by the same copyright terms\
-except that the holder is Tim Hudson (tjh@cryptsoft.com).\
-\
-Copyright remains Eric Young's, and as such any Copyright notices in\
-the code are not to be removed.\
-If this package is used in a product, Eric Young should be given attribution\
-as the author of the parts of the library used.\
-This can be in the form of a textual message at program startup or\
-in documentation (online or textual) provided with the package.\
-\
-Redistribution and use in source and binary forms, with or without\
-modification, are permitted provided that the following conditions\
-are met:\
-1. Redistributions of source code must retain the copyright\
-  notice, this list of conditions and the following disclaimer.\
-2. Redistributions in binary form must reproduce the above copyright\
-  notice, this list of conditions and the following disclaimer in the\
-  documentation and/or other materials provided with the distribution.\
-3. All advertising materials mentioning features or use of this software\
-  must display the following acknowledgement:\
-  "This product includes cryptographic software written by\
-    Eric Young (eay@cryptsoft.com)"\
-  The word 'cryptographic' can be left out if the rouines from the library\
-  being used are not cryptographic related :-).\
-4. If you include any Windows specific code (or a derivative thereof) from\
-  the apps directory (application code) you must include an acknowledgement:\
-  "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"\
-\
-THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND\
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE\
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT\
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY\
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\
-SUCH DAMAGE.\
-\
-The licence and distribution terms for any publically available version or\
-derivative of this code cannot be changed.  i.e. this code cannot simply be\
-copied and put under another distribution licence\
-[including the GNU Public Licence.]\
-\
-
-\b\fs28 MIT License:
-\b0\fs20 \
-\
-The MIT License\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy\
-of this software and associated documentation files (the "Software"), to deal\
-in the Software without restriction, including without limitation the rights\
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
-copies of the Software, and to permit persons to whom the Software is\
-furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in\
-all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
-THE SOFTWARE.\
-\
-
-\b\fs28 Ansicon zlib License:
-\b0\fs20 \
-\
-Copyright (C) 2005-2014 Jason Hood\
-\
-This software is provided 'as-is', without any express or implied\
-warranty.  In no event will the author be held liable for any damages\
-arising from the use of this software.\
-\
-Permission is granted to anyone to use this software for any purpose,\
-including commercial applications, and to alter it and redistribute it\
-freely, subject to the following restrictions:\
-\
-1. The origin of this software must not be misrepresented; you must not\
-   claim that you wrote the original software. If you use this software\
-   in a product, an acknowledgment in the product documentation would be\
-   appreciated but is not required.\
-2. Altered source versions must be plainly marked as such, and must not be\
-   misrepresented as being the original software.\
-3. This notice may not be removed or altered from any source distribution.\
-\
-Jason Hood\
-jadoxa@yahoo.com.au\
-\
-\
-
-\b\fs28 GPLv2 License Terms:
-\b0\fs20 \
-\
-		    GNU GENERAL PUBLIC LICENSE\
-		       Version 2, June 1991\
-\
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,\
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA\
- Everyone is permitted to copy and distribute verbatim copies\
- of this license document, but changing it is not allowed.\
-\
-			    Preamble\
-\
-  The licenses for most software are designed to take away your\
-freedom to share and change it.  By contrast, the GNU General Public\
-License is intended to guarantee your freedom to share and change free\
-software--to make sure the software is free for all its users.  This\
-General Public License applies to most of the Free Software\
-Foundation's software and to any other program whose authors commit to\
-using it.  (Some other Free Software Foundation software is covered by\
-the GNU Lesser General Public License instead.)  You can apply it to\
-your programs, too.\
-\
-  When we speak of free software, we are referring to freedom, not\
-price.  Our General Public Licenses are designed to make sure that you\
-have the freedom to distribute copies of free software (and charge for\
-this service if you wish), that you receive source code or can get it\
-if you want it, that you can change the software or use pieces of it\
-in new free programs; and that you know you can do these things.\
-\
-  To protect your rights, we need to make restrictions that forbid\
-anyone to deny you these rights or to ask you to surrender the rights.\
-These restrictions translate to certain responsibilities for you if you\
-distribute copies of the software, or if you modify it.\
-\
-  For example, if you distribute copies of such a program, whether\
-gratis or for a fee, you must give the recipients all the rights that\
-you have.  You must make sure that they, too, receive or can get the\
-source code.  And you must show them these terms so they know their\
-rights.\
-\
-  We protect your rights with two steps: (1) copyright the software, and\
-(2) offer you this license which gives you legal permission to copy,\
-distribute and/or modify the software.\
-\
-  Also, for each author's protection and ours, we want to make certain\
-that everyone understands that there is no warranty for this free\
-software.  If the software is modified by someone else and passed on, we\
-want its recipients to know that what they have is not the original, so\
-that any problems introduced by others will not reflect on the original\
-authors' reputations.\
-\
-  Finally, any free program is threatened constantly by software\
-patents.  We wish to avoid the danger that redistributors of a free\
-program will individually obtain patent licenses, in effect making the\
-program proprietary.  To prevent this, we have made it clear that any\
-patent must be licensed for everyone's free use or not licensed at all.\
-\
-  The precise terms and conditions for copying, distribution and\
-modification follow.\
-\
-		    GNU GENERAL PUBLIC LICENSE\
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\
-\
-  0. This License applies to any program or other work which contains\
-a notice placed by the copyright holder saying it may be distributed\
-under the terms of this General Public License.  The "Program", below,\
-refers to any such program or work, and a "work based on the Program"\
-means either the Program or any derivative work under copyright law:\
-that is to say, a work containing the Program or a portion of it,\
-either verbatim or with modifications and/or translated into another\
-language.  (Hereinafter, translation is included without limitation in\
-the term "modification".)  Each licensee is addressed as "you".\
-\
-Activities other than copying, distribution and modification are not\
-covered by this License; they are outside its scope.  The act of\
-running the Program is not restricted, and the output from the Program\
-is covered only if its contents constitute a work based on the\
-Program (independent of having been made by running the Program).\
-Whether that is true depends on what the Program does.\
-\
-  1. You may copy and distribute verbatim copies of the Program's\
-source code as you receive it, in any medium, provided that you\
-conspicuously and appropriately publish on each copy an appropriate\
-copyright notice and disclaimer of warranty; keep intact all the\
-notices that refer to this License and to the absence of any warranty;\
-and give any other recipients of the Program a copy of this License\
-along with the Program.\
-\
-You may charge a fee for the physical act of transferring a copy, and\
-you may at your option offer warranty protection in exchange for a fee.\
-\
-  2. You may modify your copy or copies of the Program or any portion\
-of it, thus forming a work based on the Program, and copy and\
-distribute such modifications or work under the terms of Section 1\
-above, provided that you also meet all of these conditions:\
-\
-    a) You must cause the modified files to carry prominent notices\
-    stating that you changed the files and the date of any change.\
-\
-    b) You must cause any work that you distribute or publish, that in\
-    whole or in part contains or is derived from the Program or any\
-    part thereof, to be licensed as a whole at no charge to all third\
-    parties under the terms of this License.\
-\
-    c) If the modified program normally reads commands interactively\
-    when run, you must cause it, when started running for such\
-    interactive use in the most ordinary way, to print or display an\
-    announcement including an appropriate copyright notice and a\
-    notice that there is no warranty (or else, saying that you provide\
-    a warranty) and that users may redistribute the program under\
-    these conditions, and telling the user how to view a copy of this\
-    License.  (Exception: if the Program itself is interactive but\
-    does not normally print such an announcement, your work based on\
-    the Program is not required to print an announcement.)\
-\
-These requirements apply to the modified work as a whole.  If\
-identifiable sections of that work are not derived from the Program,\
-and can be reasonably considered independent and separate works in\
-themselves, then this License, and its terms, do not apply to those\
-sections when you distribute them as separate works.  But when you\
-distribute the same sections as part of a whole which is a work based\
-on the Program, the distribution of the whole must be on the terms of\
-this License, whose permissions for other licensees extend to the\
-entire whole, and thus to each and every part regardless of who wrote it.\
-\
-Thus, it is not the intent of this section to claim rights or contest\
-your rights to work written entirely by you; rather, the intent is to\
-exercise the right to control the distribution of derivative or\
-collective works based on the Program.\
-\
-In addition, mere aggregation of another work not based on the Program\
-with the Program (or with a work based on the Program) on a volume of\
-a storage or distribution medium does not bring the other work under\
-the scope of this License.\
-\
-  3. You may copy and distribute the Program (or a work based on it,\
-under Section 2) in object code or executable form under the terms of\
-Sections 1 and 2 above provided that you also do one of the following:\
-\
-    a) Accompany it with the complete corresponding machine-readable\
-    source code, which must be distributed under the terms of Sections\
-    1 and 2 above on a medium customarily used for software interchange; or,\
-\
-    b) Accompany it with a written offer, valid for at least three\
-    years, to give any third party, for a charge no more than your\
-    cost of physically performing source distribution, a complete\
-    machine-readable copy of the corresponding source code, to be\
-    distributed under the terms of Sections 1 and 2 above on a medium\
-    customarily used for software interchange; or,\
-\
-    c) Accompany it with the information you received as to the offer\
-    to distribute corresponding source code.  (This alternative is\
-    allowed only for noncommercial distribution and only if you\
-    received the program in object code or executable form with such\
-    an offer, in accord with Subsection b above.)\
-\
-The source code for a work means the preferred form of the work for\
-making modifications to it.  For an executable work, complete source\
-code means all the source code for all modules it contains, plus any\
-associated interface definition files, plus the scripts used to\
-control compilation and installation of the executable.  However, as a\
-special exception, the source code distributed need not include\
-anything that is normally distributed (in either source or binary\
-form) with the major components (compiler, kernel, and so on) of the\
-operating system on which the executable runs, unless that component\
-itself accompanies the executable.\
-\
-If distribution of executable or object code is made by offering\
-access to copy from a designated place, then offering equivalent\
-access to copy the source code from the same place counts as\
-distribution of the source code, even though third parties are not\
-compelled to copy the source along with the object code.\
-\
-  4. You may not copy, modify, sublicense, or distribute the Program\
-except as expressly provided under this License.  Any attempt\
-otherwise to copy, modify, sublicense or distribute the Program is\
-void, and will automatically terminate your rights under this License.\
-However, parties who have received copies, or rights, from you under\
-this License will not have their licenses terminated so long as such\
-parties remain in full compliance.\
-\
-  5. You are not required to accept this License, since you have not\
-signed it.  However, nothing else grants you permission to modify or\
-distribute the Program or its derivative works.  These actions are\
-prohibited by law if you do not accept this License.  Therefore, by\
-modifying or distributing the Program (or any work based on the\
-Program), you indicate your acceptance of this License to do so, and\
-all its terms and conditions for copying, distributing or modifying\
-the Program or works based on it.\
-\
-  6. Each time you redistribute the Program (or any work based on the\
-Program), the recipient automatically receives a license from the\
-original licensor to copy, distribute or modify the Program subject to\
-these terms and conditions.  You may not impose any further\
-restrictions on the recipients' exercise of the rights granted herein.\
-You are not responsible for enforcing compliance by third parties to\
-this License.\
-\
-  7. If, as a consequence of a court judgment or allegation of patent\
-infringement or for any other reason (not limited to patent issues),\
-conditions are imposed on you (whether by court order, agreement or\
-otherwise) that contradict the conditions of this License, they do not\
-excuse you from the conditions of this License.  If you cannot\
-distribute so as to satisfy simultaneously your obligations under this\
-License and any other pertinent obligations, then as a consequence you\
-may not distribute the Program at all.  For example, if a patent\
-license would not permit royalty-free redistribution of the Program by\
-all those who receive copies directly or indirectly through you, then\
-the only way you could satisfy both it and this License would be to\
-refrain entirely from distribution of the Program.\
-\
-If any portion of this section is held invalid or unenforceable under\
-any particular circumstance, the balance of the section is intended to\
-apply and the section as a whole is intended to apply in other\
-circumstances.\
-\
-It is not the purpose of this section to induce you to infringe any\
-patents or other property right claims or to contest validity of any\
-such claims; this section has the sole purpose of protecting the\
-integrity of the free software distribution system, which is\
-implemented by public license practices.  Many people have made\
-generous contributions to the wide range of software distributed\
-through that system in reliance on consistent application of that\
-system; it is up to the author/donor to decide if he or she is willing\
-to distribute software through any other system and a licensee cannot\
-impose that choice.\
-\
-This section is intended to make thoroughly clear what is believed to\
-be a consequence of the rest of this License.\
-\
-  8. If the distribution and/or use of the Program is restricted in\
-certain countries either by patents or by copyrighted interfaces, the\
-original copyright holder who places the Program under this License\
-may add an explicit geographical distribution limitation excluding\
-those countries, so that distribution is permitted only in or among\
-countries not thus excluded.  In such case, this License incorporates\
-the limitation as if written in the body of this License.\
-\
-  9. The Free Software Foundation may publish revised and/or new versions\
-of the General Public License from time to time.  Such new versions will\
-be similar in spirit to the present version, but may differ in detail to\
-address new problems or concerns.\
-\
-Each version is given a distinguishing version number.  If the Program\
-specifies a version number of this License which applies to it and "any\
-later version", you have the option of following the terms and conditions\
-either of that version or of any later version published by the Free\
-Software Foundation.  If the Program does not specify a version number of\
-this License, you may choose any version ever published by the Free Software\
-Foundation.\
-\
-  10. If you wish to incorporate parts of the Program into other free\
-programs whose distribution conditions are different, write to the author\
-to ask for permission.  For software which is copyrighted by the Free\
-Software Foundation, write to the Free Software Foundation; we sometimes\
-make exceptions for this.  Our decision will be guided by the two goals\
-of preserving the free status of all derivatives of our free software and\
-of promoting the sharing and reuse of software generally.\
-\
-			    NO WARRANTY\
-\
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY\
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN\
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES\
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED\
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS\
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE\
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,\
-REPAIR OR CORRECTION.\
-\
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING\
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR\
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,\
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING\
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED\
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY\
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER\
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE\
-POSSIBILITY OF SUCH DAMAGES.\
-\
-		     END OF TERMS AND CONDITIONS\
-\
-	    How to Apply These Terms to Your New Programs\
-\
-  If you develop a new program, and you want it to be of the greatest\
-possible use to the public, the best way to achieve this is to make it\
-free software which everyone can redistribute and change under these terms.\
-\
-  To do so, attach the following notices to the program.  It is safest\
-to attach them to the start of each source file to most effectively\
-convey the exclusion of warranty; and each file should have at least\
-the "copyright" line and a pointer to where the full notice is found.\
-\
-    <one line to give the program's name and a brief idea of what it does.>\
-    Copyright (C) <year>  <name of author>\
-\
-    This program is free software; you can redistribute it and/or modify\
-    it under the terms of the GNU General Public License as published by\
-    the Free Software Foundation; either version 2 of the License, or\
-    (at your option) any later version.\
-\
-    This program is distributed in the hope that it will be useful,\
-    but WITHOUT ANY WARRANTY; without even the implied warranty of\
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\
-    GNU General Public License for more details.\
-\
-    You should have received a copy of the GNU General Public License along\
-    with this program; if not, write to the Free Software Foundation, Inc.,\
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.\
-\
-Also add information on how to contact you by electronic and paper mail.\
-\
-If the program is interactive, make it output a short notice like this\
-when it starts in an interactive mode:\
-\
-    Gnomovision version 69, Copyright (C) year name of author\
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.\
-    This is free software, and you are welcome to redistribute it\
-    under certain conditions; type `show c' for details.\
-\
-The hypothetical commands `show w' and `show c' should show the appropriate\
-parts of the General Public License.  Of course, the commands you use may\
-be called something other than `show w' and `show c'; they could even be\
-mouse-clicks or menu items--whatever suits your program.\
-\
-You should also get your employer (if you work as a programmer) or your\
-school, if any, to sign a "copyright disclaimer" for the program, if\
-necessary.  Here is a sample; alter the names:\
-\
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program\
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.\
-\
-  <signature of Ty Coon>, 1 April 1989\
-  Ty Coon, President of Vice\
-\
-This General Public License does not permit incorporating your program into\
-proprietary programs.  If your program is a subroutine library, you may\
-consider it more useful to permit linking proprietary applications with the\
-library.  If this is what you want to do, use the GNU Lesser General\
-Public License instead of this License.\
-\
-\
-
-\b\fs28 The 3-Clause BSD License
-\b0\fs20 \
-\
-Note: This license has also been called the "New BSD License" or "Modified BSD License". See also the 2-clause BSD License.\
-\
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\
-\
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\
-\
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\
-\
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\
-\
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\
-}
+{\rtf1\ansi\ansicpg1252\deff0\uc1
+{\fonttbl
+{\f0\fnil\fcharset0\fprq0\fttruetype ArialMT;}
+{\f1\fnil\fcharset0\fprq0\fttruetype Helvetica;}
+{\f2\fnil\fcharset0\fprq0\fttruetype Liberation Sans;}
+{\f3\fnil\fcharset0\fprq0\fttruetype Liberation Serif;}
+{\f4\fnil\fcharset0\fprq0\fttruetype Courier New;}}
+{\colortbl
+\red0\green0\blue0;
+\red255\green255\blue255;
+\red255\green255\blue255;
+\red0\green0\blue255;}
+{\stylesheet
+{\s6\fi-431\li720\sbasedon28\snext28 Contents 1;}
+{\s7\fi-431\li1440\sbasedon28\snext28 Contents 2;}
+{\s1\fi-431\li720 Arrowhead List;}
+{\s27\fi-431\li720\sbasedon28 Lower Roman List;}
+{\s29\tx431\sbasedon20\snext28 Numbered Heading 1;}
+{\s30\tx431\sbasedon21\snext28 Numbered Heading 2;}
+{\s12\fi-431\li720 Diamond List;}
+{\s9\fi-431\li2880\sbasedon28\snext28 Contents 4;}
+{\s8\fi-431\li2160\sbasedon28\snext28 Contents 3;}
+{\s31\tx431\sbasedon22\snext28 Numbered Heading 3;}
+{\s32\fi-431\li720 Numbered List;}
+{\s15\sbasedon28 Endnote Text;}
+{\*\cs14\fs20\super Endnote Reference;}
+{\s4\fi-431\li720 Bullet List;}
+{\s5\tx1584\sbasedon29\snext28 Chapter Heading;}
+{\s35\fi-431\li720 Square List;}
+{\s11\fi-431\li720 Dashed List;}
+{\s22\sb440\sa60\f2\fs24\b\sbasedon28\snext28 Heading 3;}
+{\s37\fi-431\li720 Tick List;}
+{\s24\fi-431\li720 Heart List;}
+{\s40\fi-431\li720\sbasedon32 Upper Roman List;}
+{\s39\fi-431\li720\sbasedon32 Upper Case List;}
+{\s16\fi-288\li288\fs20\sbasedon28 Footnote;}
+{\s19\fi-431\li720 Hand List;}
+{\s18\fs20\sbasedon28 Footnote Text;}
+{\s20\sb440\sa60\f2\fs34\b\sbasedon28\snext28 Heading 1;}
+{\s21\sb440\sa60\f2\fs28\b\sbasedon28\snext28 Heading 2;}
+{\s10\qc\sb240\sa120\f2\fs32\b\sbasedon28\snext28 Contents Header;}
+{\s23\sb440\sa60\f2\fs24\b\sbasedon28\snext28 Heading 4;}
+{\s28\f3\fs24 Normal;}
+{\s26\fi-431\li720\sbasedon32 Lower Case List;}
+{\s2\li1440\ri1440\sa120\sbasedon28 Block Text;}
+{\s33\f4\sbasedon28 Plain Text;}
+{\s34\tx1584\sbasedon29\snext28 Section Heading;}
+{\s25\fi-431\li720 Implies List;}
+{\s3\fi-431\li720 Box List;}
+{\s36\fi-431\li720 Star List;}
+{\*\cs17\fs20\super Footnote Reference;}
+{\s38\fi-431\li720 Triangle List;}
+{\s13\fi-288\li288\sbasedon28 Endnote;}}
+\kerning0\cf0\ftnbj\fet2\ftnstart1\ftnnar\aftnnar\ftnstart1\aftnstart1\aenddoc\revprop3{\*\rdf}{\info\uc1}\deftab720\viewkind1\paperw11900\paperh16839\margl1440\margr1440\widowctrl
+\sectd\sbknone\colsx0\marglsxn1800\margrsxn1800\pgncont\ltrsect
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch License Summary:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\fi-360\li360\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Puppet Development Kit - Apache 2.0 License (Copyright (c) 2017 Puppet, Inc.)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\fi-360\li360\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Ruby - Ruby License (Copyright (c) Yukihiro Matsumoto)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\fi-360\li360\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch WiX Toolset - Microsoft Reciprocal License (MS-RL)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch openssl - Openssl Dual License}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch curl - Curl License}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ansicon - zlib License}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch git/Git For Windows - GNU General Public License v2}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch bundler - MIT License (Portions copyright (c) 2010 Andre Arko, Portions copyright (c) 2009 Engine Yard)}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch childprocess - MIT License (Copyright (c) 2010-2015 Jari Bakken)}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch colored - MIT License (Copyright (c) 2010 Chris Wanstrath)}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch cri - MIT License (Copyright (c) 2015 Denis Defreyne and contributors)}{\f1\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch deep_merge - MIT License (Copyright (c) 2008-2016 Steve Midgley, Daniel DeLeo)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch equatable - MIT License (Copyright (c) 2012 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Fast Gettext - MIT License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ffi - BSD 3-clause License (Copyright (c) 2008-2016, Ruby FFI project contributors All rights reserved.)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch gettext-setup - Apache 2.0 License (Copyright (C) 2016 Puppet, Inc.)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch gettext - Ruby License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch hitimes - ISC License (Copyright (c) 2008-2015 Jeremy Hinegardner)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch json_pure - Ruby License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch locale - Ruby License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch necromancer - MIT License (Copyright (c) 2014 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch pastel - MIT License (Copyright (c) 2014 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch text - MIT License (Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch timers - MIT License (Copyright (c) 2012-2017, Timers Gem Developers)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch tty-color - MIT License (Copyright (c) 2016 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch tty-cursor - MIT License (Copyright (c) 2015 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch tty-prompt - MIT License (Copyright (c) 2015 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch tty-spinner - MIT License (Copyright (c) 2014 Piotr Murach)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch wisper - MIT License (Copyright (c) 2013 Kris Leech)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\qc\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f1\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Apache 2.0}{\f0\fs28\b\lang3081{\*\listtag0} License Terms:}{\f1\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\qc\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Apache License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Version 2.0, January 2004}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\field{\*\fldinst {\f3\fs24\lang3081{\*\listtag0} HYPERLINK "http://www.apache.org/licenses/"}}{\*\fldrslt{\cf3\f0\fs20\ul\lang3081{\*\listtag0}\abinodiroverride\ltrch http://www.apache.org/licenses/}}}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\cf3\f0\fs20\ul\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. Definitions.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation, source, and configuration files.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license plies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch       (a) You must give any other recipients of the Work or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           Derivative Works a copy of this License; and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch       (b) You must cause any modified files to carry prominent notices}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           stating that You changed the files; and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch       (c) You must retain, in the Source form of any Derivative Works}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           that You distribute, all copyright, patent, trademark, and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           attribution notices from the Source form of the Work,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           excluding those notices that do not pertain to any part of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           the Derivative Works; and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch       (d) If the Work includes a "NOTICE" text file as part of its}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           distribution, then any Derivative Works that You distribute}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           must include a readable copy of the attribution notices}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           contained within such NOTICE file, excluding those notices}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           that do not pertain to any part of the Derivative Works, in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           at least one of the following places: within a NOTICE text}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           file distributed as part of the Derivative Works; within the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           Source form or documentation, if provided along with the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           Derivative Works; or, within a display generated by the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           Derivative Works, if and wherever such third-party notices}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           normally appear. The contents of the NOTICE file are for}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           informational purposes only and do not modify the License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           You may add Your own attribution notices within Derivative}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           Works that You distribute, alongside or as an addendum to the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           NOTICE text from the Work, provided that such additional}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           attribution notices cannot be construed as modifying the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch END OF TERMS AND CONDITIONS}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch APPENDIX: How to apply the Apache License to your work.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    Copyright [yyyy] [name of copyright owner]}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    Licensed under the Apache License, Version 2.0 (the "License");}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    you may not use this file except in compliance with the License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    You may obtain a copy of the License at}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        }{\field{\*\fldinst {\f3\fs24\lang3081{\*\listtag0} HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0"}}{\*\fldrslt{\cf3\f0\fs20\ul\lang3081{\*\listtag0}http://www.apache.org/licenses/LICENSE-2.0}}}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\cf3\f0\fs20\ul\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    Unless required by applicable law or agreed to in writing, software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    distributed under the License is distributed on an "AS IS" BASIS,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    implied. See the License for the specific language governing}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    permissions and limitations under the License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Ruby License Terms:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.co.jp>.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch You can redistribute it and/or modify it under either the terms of the GPL}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (see COPYING.txt file), or the conditions below:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   1. You may make and give away verbatim copies of the source form of the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      software without restriction, provided that you duplicate all of the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      original copyright notices and associated disclaimers.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   2. You may modify your copy of the software in any way, provided that}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      you do at least ONE of the following:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        a) place your modifications in the Public Domain or otherwise}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           make them Freely Available, such as by posting said}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   modifications to Usenet or an equivalent medium, or by allowing}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   the author to include your modifications in the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        b) use the modified software only within your corporation or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           organization.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        c) rename any non-standard executables so the names do not conflict}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   with standard executables, which must also be provided.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        d) make other distribution arrangements with the author.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   3. You may distribute the software in object code or executable}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      form, provided that you do at least ONE of the following:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        a) distribute the executables and library files of the software,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   together with instructions (in the manual page or equivalent)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   on where to get the original distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        b) accompany the distribution with the machine-readable source of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab   the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        c) give non-standard executables non-standard names, with}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch           instructions on where to get the original software distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch        d) make other distribution arrangements with the author.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   4. You may modify and include the part of the software into any other}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      software (possibly commercial).  But some files in the distribution}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      are not written by the author, so that they are not under this terms.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      They are gc.c(partly), utils.c(partly), regex.[ch], st.[ch] and some}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      files under the ./missing directory.  See each file for the copying}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      condition.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   5. The scripts and library files supplied as input to or produced as }{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      output from the software do not automatically fall under the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      copyright of the software, but belong to whomever generated them, }{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      and may be sold commercially, and may be aggregated with this}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch      PURPOSE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Microsoft Reciprocal License (MS-RL)}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. Definitions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch A "contribution" is the original software, or any additions or changes to the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch A "contributor" is any person that distributes its contribution under this license.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch "Licensed patents" are a contributor's patent claims that read directly on its contribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Grant of Rights}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. Conditions and Limitations}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (A) Reciprocal Grants- For any file you distribute that contains code from the software (in source code or binary format), you must provide recipients the source code to that file along with a copy of this license, which license will govern that file. You may license other files that are entirely your own work and do not contain code from the software under any terms you choose.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (B) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (C) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (D) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (E) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (F) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Curl License Terms:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch COPYRIGHT AND PERMISSION NOTICE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Copyright (c) 1996 - 2016, Daniel Stenberg, daniel@haxx.se, and many contributors, see the THANKS file.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch All rights reserved.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization of the copyright holder.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Openssl Dual License Terms:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch LICENSE ISSUES}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ==============}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The OpenSSL toolkit stays under a dual license, i.e. both the conditions of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the OpenSSL License and the original SSLeay license apply to the toolkit.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch See below for the actual license texts.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OpenSSL License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ---------------}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ====================================================================}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Redistribution and use in source and binary forms, with or without}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch modification, are permitted provided that the following conditions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch are met:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. Redistributions of source code must retain the above copyright}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   notice, this list of conditions and the following disclaimer.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Redistributions in binary form must reproduce the above copyright}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   notice, this list of conditions and the following disclaimer in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   the documentation and/or other materials provided with the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. All advertising materials mentioning features or use of this}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   software must display the following acknowledgment:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   "This product includes software developed by the OpenSSL Project}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   for use in the OpenSSL Toolkit. (http://www.openssl.org/)"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   endorse or promote products derived from this software without}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   prior written permission. For written permission, please contact}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   openssl-core@openssl.org.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 5. Products derived from this software may not be called "OpenSSL"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   nor may "OpenSSL" appear in their names without prior written}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   permission of the OpenSSL Project.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 6. Redistributions of any form whatsoever must retain the following}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   acknowledgment:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   "This product includes software developed by the OpenSSL Project}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   for use in the OpenSSL Toolkit (http://www.openssl.org/)"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OF THE POSSIBILITY OF SUCH DAMAGE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ====================================================================}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This product includes cryptographic software written by Eric Young}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (eay@cryptsoft.com).  This product includes software written by Tim}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Hudson (tjh@cryptsoft.com).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Original SSLeay License}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch All rights reserved.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This package is an SSL implementation written}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch by Eric Young (eay@cryptsoft.com).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The implementation was written so as to conform with Netscapes SSL.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This library is free for commercial and non-commercial use as long as}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the following conditions are aheared to.  The following conditions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch apply to all code found in this distribution, be it the RC4, RSA,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch lhash, DES, etc., code; not just the SSL code.  The SSL documentation}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch included with this distribution is covered by the same copyright terms}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch except that the holder is Tim Hudson (tjh@cryptsoft.com).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Copyright remains Eric Young's, and as such any Copyright notices in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the code are not to be removed.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch If this package is used in a product, Eric Young should be given attribution}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch as the author of the parts of the library used.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This can be in the form of a textual message at program startup or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch in documentation (online or textual) provided with the package.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Redistribution and use in source and binary forms, with or without}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch modification, are permitted provided that the following conditions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch are met:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. Redistributions of source code must retain the copyright}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   notice, this list of conditions and the following disclaimer.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Redistributions in binary form must reproduce the above copyright}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   notice, this list of conditions and the following disclaimer in the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   documentation and/or other materials provided with the distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. All advertising materials mentioning features or use of this software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   must display the following acknowledgement:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   "This product includes cryptographic software written by}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     Eric Young (eay@cryptsoft.com)"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   The word 'cryptographic' can be left out if the rouines from the library}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   being used are not cryptographic related :-).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 4. If you include any Windows specific code (or a derivative thereof) from}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   the apps directory (application code) you must include an acknowledgement:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch SUCH DAMAGE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The licence and distribution terms for any publically available version or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch derivative of this code cannot be changed.  i.e. this code cannot simply be}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch copied and put under another distribution licence}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch [including the GNU Public Licence.]}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch MIT License:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The MIT License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Permission is hereby granted, free of charge, to any person obtaining a copy}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch of this software and associated documentation files (the "Software"), to deal}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch in the Software without restriction, including without limitation the rights}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch to use, copy, modify, merge, publish, distribute, sublicense, and/or sell}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch copies of the Software, and to permit persons to whom the Software is}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch furnished to do so, subject to the following conditions:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The above copyright notice and this permission notice shall be included in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch all copies or substantial portions of the Software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THE SOFTWARE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch Ansicon zlib License:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Copyright (C) 2005-2014 Jason Hood}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This software is provided 'as-is', without any express or implied}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch warranty.  In no event will the author be held liable for any damages}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch arising from the use of this software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Permission is granted to anyone to use this software for any purpose,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch including commercial applications, and to alter it and redistribute it}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch freely, subject to the following restrictions:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. The origin of this software must not be misrepresented; you must not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    claim that you wrote the original software. If you use this software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    in a product, an acknowledgment in the product documentation would be}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    appreciated but is not required.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Altered source versions must be plainly marked as such, and must not be}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    misrepresented as being the original software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. This notice may not be removed or altered from any source distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Jason Hood}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch jadoxa@yahoo.com.au}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch GPLv2 License Terms:}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab     GNU GENERAL PUBLIC LICENSE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab        Version 2, June 1991}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch  Everyone is permitted to copy and distribute verbatim copies}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch  of this license document, but changing it is not allowed.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab \tab     Preamble}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   The licenses for most software are designed to take away your}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch freedom to share and change it.  By contrast, the GNU General Public}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch License is intended to guarantee your freedom to share and change free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch software--to make sure the software is free for all its users.  This}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch General Public License applies to most of the Free Software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Foundation's software and to any other program whose authors commit to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch using it.  (Some other Free Software Foundation software is covered by}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the GNU Lesser General Public License instead.)  You can apply it to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch your programs, too.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   When we speak of free software, we are referring to freedom, not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch price.  Our General Public Licenses are designed to make sure that you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch have the freedom to distribute copies of free software (and charge for}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch this service if you wish), that you receive source code or can get it}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch if you want it, that you can change the software or use pieces of it}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch in new free programs; and that you know you can do these things.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   To protect your rights, we need to make restrictions that forbid}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch anyone to deny you these rights or to ask you to surrender the rights.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch These restrictions translate to certain responsibilities for you if you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute copies of the software, or if you modify it.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   For example, if you distribute copies of such a program, whether}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch gratis or for a fee, you must give the recipients all the rights that}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch you have.  You must make sure that they, too, receive or can get the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch source code.  And you must show them these terms so they know their}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch rights.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   We protect your rights with two steps: (1) copyright the software, and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch (2) offer you this license which gives you legal permission to copy,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute and/or modify the software.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   Also, for each author's protection and ours, we want to make certain}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch that everyone understands that there is no warranty for this free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch software.  If the software is modified by someone else and passed on, we}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch want its recipients to know that what they have is not the original, so}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch that any problems introduced by others will not reflect on the original}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch authors' reputations.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   Finally, any free program is threatened constantly by software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch patents.  We wish to avoid the danger that redistributors of a free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch program will individually obtain patent licenses, in effect making the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch program proprietary.  To prevent this, we have made it clear that any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch patent must be licensed for everyone's free use or not licensed at all.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   The precise terms and conditions for copying, distribution and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch modification follow.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab     GNU GENERAL PUBLIC LICENSE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   0. This License applies to any program or other work which contains}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch a notice placed by the copyright holder saying it may be distributed}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch under the terms of this General Public License.  The "Program", below,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch refers to any such program or work, and a "work based on the Program"}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch means either the Program or any derivative work under copyright law:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch that is to say, a work containing the Program or a portion of it,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch either verbatim or with modifications and/or translated into another}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch language.  (Hereinafter, translation is included without limitation in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the term "modification".)  Each licensee is addressed as "you".}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Activities other than copying, distribution and modification are not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch covered by this License; they are outside its scope.  The act of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch running the Program is not restricted, and the output from the Program}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch is covered only if its contents constitute a work based on the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Program (independent of having been made by running the Program).}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Whether that is true depends on what the Program does.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   1. You may copy and distribute verbatim copies of the Program's}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch source code as you receive it, in any medium, provided that you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch conspicuously and appropriately publish on each copy an appropriate}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch copyright notice and disclaimer of warranty; keep intact all the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch notices that refer to this License and to the absence of any warranty;}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch and give any other recipients of the Program a copy of this License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch along with the Program.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch You may charge a fee for the physical act of transferring a copy, and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch you may at your option offer warranty protection in exchange for a fee.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   2. You may modify your copy or copies of the Program or any portion}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch of it, thus forming a work based on the Program, and copy and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute such modifications or work under the terms of Section 1}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch above, provided that you also meet all of these conditions:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     a) You must cause the modified files to carry prominent notices}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     stating that you changed the files and the date of any change.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     b) You must cause any work that you distribute or publish, that in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     whole or in part contains or is derived from the Program or any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     part thereof, to be licensed as a whole at no charge to all third}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     parties under the terms of this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     c) If the modified program normally reads commands interactively}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     when run, you must cause it, when started running for such}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     interactive use in the most ordinary way, to print or display an}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     announcement including an appropriate copyright notice and a}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     notice that there is no warranty (or else, saying that you provide}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     a warranty) and that users may redistribute the program under}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     these conditions, and telling the user how to view a copy of this}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     License.  (Exception: if the Program itself is interactive but}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     does not normally print such an announcement, your work based on}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     the Program is not required to print an announcement.)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch These requirements apply to the modified work as a whole.  If}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch identifiable sections of that work are not derived from the Program,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch and can be reasonably considered independent and separate works in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch themselves, then this License, and its terms, do not apply to those}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch sections when you distribute them as separate works.  But when you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute the same sections as part of a whole which is a work based}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch on the Program, the distribution of the whole must be on the terms of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch this License, whose permissions for other licensees extend to the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch entire whole, and thus to each and every part regardless of who wrote it.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Thus, it is not the intent of this section to claim rights or contest}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch your rights to work written entirely by you; rather, the intent is to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch exercise the right to control the distribution of derivative or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch collective works based on the Program.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch In addition, mere aggregation of another work not based on the Program}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch with the Program (or with a work based on the Program) on a volume of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch a storage or distribution medium does not bring the other work under}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the scope of this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   3. You may copy and distribute the Program (or a work based on it,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch under Section 2) in object code or executable form under the terms of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Sections 1 and 2 above provided that you also do one of the following:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     a) Accompany it with the complete corresponding machine-readable}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     source code, which must be distributed under the terms of Sections}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     1 and 2 above on a medium customarily used for software interchange; or,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     b) Accompany it with a written offer, valid for at least three}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     years, to give any third party, for a charge no more than your}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     cost of physically performing source distribution, a complete}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     machine-readable copy of the corresponding source code, to be}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     distributed under the terms of Sections 1 and 2 above on a medium}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     customarily used for software interchange; or,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     c) Accompany it with the information you received as to the offer}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     to distribute corresponding source code.  (This alternative is}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     allowed only for noncommercial distribution and only if you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     received the program in object code or executable form with such}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     an offer, in accord with Subsection b above.)}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The source code for a work means the preferred form of the work for}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch making modifications to it.  For an executable work, complete source}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch code means all the source code for all modules it contains, plus any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch associated interface definition files, plus the scripts used to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch control compilation and installation of the executable.  However, as a}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch special exception, the source code distributed need not include}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch anything that is normally distributed (in either source or binary}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch form) with the major components (compiler, kernel, and so on) of the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch operating system on which the executable runs, unless that component}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch itself accompanies the executable.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch If distribution of executable or object code is made by offering}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch access to copy from a designated place, then offering equivalent}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch access to copy the source code from the same place counts as}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribution of the source code, even though third parties are not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch compelled to copy the source along with the object code.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   4. You may not copy, modify, sublicense, or distribute the Program}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch except as expressly provided under this License.  Any attempt}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch otherwise to copy, modify, sublicense or distribute the Program is}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch void, and will automatically terminate your rights under this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch However, parties who have received copies, or rights, from you under}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch this License will not have their licenses terminated so long as such}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch parties remain in full compliance.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   5. You are not required to accept this License, since you have not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch signed it.  However, nothing else grants you permission to modify or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute the Program or its derivative works.  These actions are}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch prohibited by law if you do not accept this License.  Therefore, by}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch modifying or distributing the Program (or any work based on the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Program), you indicate your acceptance of this License to do so, and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch all its terms and conditions for copying, distributing or modifying}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the Program or works based on it.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   6. Each time you redistribute the Program (or any work based on the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Program), the recipient automatically receives a license from the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch original licensor to copy, distribute or modify the Program subject to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch these terms and conditions.  You may not impose any further}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch restrictions on the recipients' exercise of the rights granted herein.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch You are not responsible for enforcing compliance by third parties to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   7. If, as a consequence of a court judgment or allegation of patent}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch infringement or for any other reason (not limited to patent issues),}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch conditions are imposed on you (whether by court order, agreement or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch otherwise) that contradict the conditions of this License, they do not}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch excuse you from the conditions of this License.  If you cannot}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch distribute so as to satisfy simultaneously your obligations under this}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch License and any other pertinent obligations, then as a consequence you}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch may not distribute the Program at all.  For example, if a patent}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch license would not permit royalty-free redistribution of the Program by}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch all those who receive copies directly or indirectly through you, then}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the only way you could satisfy both it and this License would be to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch refrain entirely from distribution of the Program.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch If any portion of this section is held invalid or unenforceable under}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch any particular circumstance, the balance of the section is intended to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch apply and the section as a whole is intended to apply in other}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch circumstances.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch It is not the purpose of this section to induce you to infringe any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch patents or other property right claims or to contest validity of any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch such claims; this section has the sole purpose of protecting the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch integrity of the free software distribution system, which is}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch implemented by public license practices.  Many people have made}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch generous contributions to the wide range of software distributed}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch through that system in reliance on consistent application of that}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch system; it is up to the author/donor to decide if he or she is willing}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch to distribute software through any other system and a licensee cannot}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch impose that choice.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This section is intended to make thoroughly clear what is believed to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch be a consequence of the rest of this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   8. If the distribution and/or use of the Program is restricted in}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch certain countries either by patents or by copyrighted interfaces, the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch original copyright holder who places the Program under this License}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch may add an explicit geographical distribution limitation excluding}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch those countries, so that distribution is permitted only in or among}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch countries not thus excluded.  In such case, this License incorporates}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the limitation as if written in the body of this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   9. The Free Software Foundation may publish revised and/or new versions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch of the General Public License from time to time.  Such new versions will}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch be similar in spirit to the present version, but may differ in detail to}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch address new problems or concerns.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Each version is given a distinguishing version number.  If the Program}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch specifies a version number of this License which applies to it and "any}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch later version", you have the option of following the terms and conditions}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch either of that version or of any later version published by the Free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Software Foundation.  If the Program does not specify a version number of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch this License, you may choose any version ever published by the Free Software}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Foundation.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   10. If you wish to incorporate parts of the Program into other free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch programs whose distribution conditions are different, write to the author}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch to ask for permission.  For software which is copyrighted by the Free}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Software Foundation, write to the Free Software Foundation; we sometimes}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch make exceptions for this.  Our decision will be guided by the two goals}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch of preserving the free status of all derivatives of our free software and}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch of promoting the sharing and reuse of software generally.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab \tab     NO WARRANTY}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch REPAIR OR CORRECTION.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch POSSIBILITY OF SUCH DAMAGES.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab \tab      END OF TERMS AND CONDITIONS}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch \tab     How to Apply These Terms to Your New Programs}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   If you develop a new program, and you want it to be of the greatest}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch possible use to the public, the best way to achieve this is to make it}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch free software which everyone can redistribute and change under these terms.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   To do so, attach the following notices to the program.  It is safest}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch to attach them to the start of each source file to most effectively}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch convey the exclusion of warranty; and each file should have at least}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch the "copyright" line and a pointer to where the full notice is found.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     <one line to give the program's name and a brief idea of what it does.>}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     Copyright (C) <year>  <name of author>}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     This program is free software; you can redistribute it and/or modify}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     it under the terms of the GNU General Public License as published by}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     the Free Software Foundation; either version 2 of the License, or}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     (at your option) any later version.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     This program is distributed in the hope that it will be useful,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     but WITHOUT ANY WARRANTY; without even the implied warranty of}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     GNU General Public License for more details.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     You should have received a copy of the GNU General Public License along}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     with this program; if not, write to the Free Software Foundation, Inc.,}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Also add information on how to contact you by electronic and paper mail.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch If the program is interactive, make it output a short notice like this}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch when it starts in an interactive mode:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     Gnomovision version 69, Copyright (C) year name of author}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     This is free software, and you are welcome to redistribute it}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch     under certain conditions; type `show c' for details.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch The hypothetical commands `show w' and `show c' should show the appropriate}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch parts of the General Public License.  Of course, the commands you use may}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch be called something other than `show w' and `show c'; they could even be}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch mouse-clicks or menu items--whatever suits your program.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch You should also get your employer (if you work as a programmer) or your}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch school, if any, to sign a "copyright disclaimer" for the program, if}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch necessary.  Here is a sample; alter the names:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   Yoyodyne, Inc., hereby disclaims all copyright interest in the program}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   `Gnomovision' (which makes passes at compilers) written by James Hacker.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   <signature of Ty Coon>, 1 April 1989}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch   Ty Coon, President of Vice}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch This General Public License does not permit incorporating your program into}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch proprietary programs.  If your program is a subroutine library, you may}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch consider it more useful to permit linking proprietary applications with the}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch library.  If this is what you want to do, use the GNU Lesser General}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Public License instead of this License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch The 3-Clause BSD License}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Note: This license has also been called the "New BSD License" or "Modified BSD License". See also the 2-clause BSD License.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.}{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\abinodiroverride\ltrch ISC License Terms}{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\sl240\slmult1\itap0{\f0\fs28\b\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\s28\sl240\slmult1\itap0{\s28\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. }{\s28\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\s28\sl240\slmult1\itap0{\s28\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\s28\sl240\slmult1\itap0{\s28\f0\fs20\lang3081{\*\listtag0}\abinodiroverride\ltrch THE SOFTWARE IS PROVIDED \uc1\u8220\'93AS IS\uc1\u8221\'94 AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. }{\s28\f0\fs20\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\s28\sl240\slmult1\itap0{\s28\f3\fs24\lang3081{\*\listtag0}\par}
+\pard\plain\ltrpar\ql\s28\sl240\slmult1\itap0{\s28\f3\fs24\lang3081{\*\listtag0}\par}}


### PR DESCRIPTION
Abiword apparently uses a different RTF format than what was used to make this file originally, so the entire file is changed in the diff. I built a windows package to make sure that the Abiword generated RTF works as expected in the installer and it's :+1: