### PR TITLE
(PDK-463) Fix PowerShell v2 Support

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
@@ -1,5 +1,5 @@
 @{
-  RootModule        = 'PuppetDevelopmentKit.psm1'
+  ModuleToProcess   = 'PuppetDevelopmentKit.psm1'
   ModuleVersion     = '0.4.0'
   GUID              = 'bfe70e90-1802-4f6b-b4a0-f627d53f593f'
   Author            = "Puppet, Inc"


### PR DESCRIPTION
This correctly supports PowerShell v2 and greater by changing
`RootModule` to `ModuleToProcess` in the manifest file. This does not
reduce functionality in v3 or greater, just ensures that v2 is
supported. We can revert this back to `RootModule` when we drop v2
support.