### PR TITLE
Relax version spec in pdk install command

### DIFF
--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -11,7 +11,7 @@ component "rubygem-pdk" do |pkg, settings, platform|
   pkg.install do
     [
       "#{settings[:host_gem]} build pdk.gemspec",
-      "#{settings[:gem_install]} pdk-#{pkg.get_version}.gem",
+      "#{settings[:gem_install]} pdk-#{pkg.get_version.tr('-', '.')}*.gem",
     ]
   end
 


### PR DESCRIPTION
Unreleased versions break currently in CI:

```
23:08:04   Successfully built RubyGem
23:08:04   Name: pdk
23:08:04   Version: 1.3.0.pre.pre
23:08:04   File: pdk-1.3.0.pre.pre.gem
23:08:04 ERROR:  Could not find a valid gem 'pdk-1.3.0-pre.gem' (>= 0) in any repository
23:08:04 Makefile:1200: recipe for target 'rubygem-pdk-install' failed
23:08:04 make: *** [rubygem-pdk-install] Error 2
```