### PR TITLE
(RE-9648) Migrate vanagon projects to use buildsources in Artifactory

### DIFF
--- a/configs/components/ansicon.rb
+++ b/configs/components/ansicon.rb
@@ -1,7 +1,7 @@
 component "ansicon" do |pkg, settings, platform|
   pkg.version '1.71'
   pkg.md5sum '0e052ad64167f6e57baebcae1b7eef42'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ansicon-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:buildsources_url]}/ansicon-#{pkg.get_version}.tar.gz"
 
   # This component should only be included on Windows
   pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,7 +1,7 @@
 component 'augeas' do |pkg, settings, platform|
   pkg.version '1.8.1'
   pkg.md5sum '623ff89d71a42fab9263365145efdbfa'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/augeas-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:buildsources_url]}/augeas-#{pkg.get_version}.tar.gz"
 
   # pkg.replaces 'pe-augeas'
   if platform.is_sles? && platform.os_version == '10'

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -2,7 +2,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.version '7.56.1'
   pkg.md5sum '48ba7bd7b363b40cd446d1e7b4be9920'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     # Patch to disable _ALL_SOURCE when including select.h from multi.c. See patch for details.

--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -2,7 +2,7 @@ component "git" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.version "2.14.2.3"
     pkg.md5sum "486fb9f0a73469b4634edecdff503091"
-    pkg.url "http://buildsources.delivery.puppetlabs.net/MinGit-#{pkg.get_version}-64-bit.zip"
+    pkg.url "#{settings[:buildsources_url]}/MinGit-#{pkg.get_version}-64-bit.zip"
   else
     pkg.version "2.14.2"
     pkg.md5sum "240b2e339029da98dd87ffbc44934278"

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -2,7 +2,7 @@ component "libxml2" do |pkg, settings, platform|
   pkg.version "2.9.4"
   pkg.md5sum "ae249165c173b1ff386ee8ad676815f5"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxml2-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxml2-#{pkg.get_version}.tar.gz"
   # CVE-related patches needed until libxml 2.9.5 is released:
   pkg.apply_patch 'resources/patches/libxml2/fix_XPointer_paths_beginning_with_range-to_CVE-2016-5131.patch'
   pkg.apply_patch 'resources/patches/libxml2/fix_comparison_with_root_node_in_xmlXPathCmpNodes.patch'

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -2,7 +2,7 @@ component "libxslt" do |pkg, settings, platform|
   pkg.version "1.1.29"
   pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxslt-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxslt-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -2,7 +2,7 @@ component "openssl" do |pkg, settings, platform|
   ## SOURCE METADATA
   pkg.version "1.0.2j"
   pkg.md5sum "96322138f0b69e61b7212bc53d5e912b"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
   ## PACKAGE DEPENDENCIES
 

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -2,11 +2,11 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     # elevate.exe is not used in the PDK
-    # pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
+    # pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
     # pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
     pkg.add_source "file://resources/files/ruby_219/windows_ruby_gem_wrapper.bat"
   end

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -2,7 +2,7 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
   pkg.url "http://download.augeas.net/ruby/ruby-augeas-#{pkg.get_version}.tgz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-augeas-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-augeas-#{pkg.get_version}.tar.gz"
 
   # pkg.replaces 'pe-ruby-augeas'
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -5,12 +5,12 @@ component "ruby-selinux" do |pkg, settings, platform|
     pkg.md5sum "08762379de2242926854080dad649b67"
     pkg.apply_patch "resources/patches/ruby-selinux/libselinux-rhat.patch"
     pkg.url "http://pkgs.fedoraproject.org/repo/pkgs/libselinux/libselinux-1.33.4.tgz/08762379de2242926854080dad649b67/libselinux-1.33.4.tgz"
-    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
+    pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tgz"
   else
     pkg.version "2.0.94"
     pkg.md5sum "544f75aab11c2af352facc51af12029f"
     pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
-    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tar.gz"
+    pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tar.gz"
   end
 
   # pkg.replaces 'pe-ruby-selinux'

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -2,7 +2,7 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.4.4"
   pkg.md5sum "1224b9efe7381cea25c506c9c6e28373"
   pkg.url "https://rubygems.org/downloads/stomp-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/stomp-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/stomp-#{pkg.get_version}.gem"
 
   # pkg.replaces 'pe-ruby-stomp'
 

--- a/configs/components/rubygem-addressable.rb
+++ b/configs/components/rubygem-addressable.rb
@@ -1,7 +1,7 @@
 component "rubygem-addressable" do |pkg, settings, platform|
   pkg.version "2.5.2"
   pkg.md5sum "b469195cee7d4ebcd492cf7c514a5ad8"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/addressable-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/addressable-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-bundler.rb
+++ b/configs/components/rubygem-bundler.rb
@@ -1,7 +1,7 @@
 component "rubygem-bundler" do |pkg, settings, platform|
   pkg.version settings[:bundler_version]
   pkg.md5sum "329064ce58948d8c38b7543340ce9068"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/bundler-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/bundler-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-childprocess.rb
+++ b/configs/components/rubygem-childprocess.rb
@@ -1,7 +1,7 @@
 component "rubygem-childprocess" do |pkg, settings, platform|
   pkg.version "0.7.1"
   pkg.md5sum "7256bd0c8e65e34903b7540fab490441"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/childprocess-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/childprocess-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-colored.rb
+++ b/configs/components/rubygem-colored.rb
@@ -2,7 +2,7 @@ component "rubygem-colored" do |pkg, settings, platform|
   gemname = pkg.get_name.gsub('rubygem-', '')
   pkg.version "1.2"
   pkg.md5sum "1b1a0f16f7c6ab57d1a2d6de53b13c42"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,7 +1,7 @@
 component "rubygem-cri" do |pkg, settings, platform|
   pkg.version "2.9.1"
   pkg.md5sum "a69b95364558623133d15ad25a7be46a"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/cri-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/cri-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-deep_merge.rb
+++ b/configs/components/rubygem-deep_merge.rb
@@ -1,7 +1,7 @@
 component "rubygem-deep_merge" do |pkg, settings, platform|
   pkg.version "1.1.1"
   pkg.md5sum "1b2527fa722b54bf0406fd7ab6cc5e08"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/deep_merge-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/deep_merge-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-equatable.rb
+++ b/configs/components/rubygem-equatable.rb
@@ -1,7 +1,7 @@
 component "rubygem-equatable" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "9ac7bbe951d558cec7e1d09313a1b79e"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/equatable-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/equatable-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,7 +1,7 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
   pkg.version "1.1.0"
   pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/fast_gettext-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/fast_gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -2,7 +2,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
   gemname = pkg.get_name.gsub('rubygem-', '')
   pkg.version "1.9.18"
   pkg.md5sum "37284a51e5464443f7122b388329a2a0"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,7 +1,7 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
   pkg.version "0.24"
   pkg.md5sum "f766a5e12bbad9f85905638c500e08f6"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/gettext-setup-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -1,7 +1,7 @@
 component "rubygem-gettext" do |pkg, settings, platform|
   pkg.version "3.2.2"
   pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/gettext-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-hitimes.rb
+++ b/configs/components/rubygem-hitimes.rb
@@ -2,7 +2,7 @@ component "rubygem-hitimes" do |pkg, settings, platform|
   gemname = pkg.get_name.gsub('rubygem-', '')
   pkg.version "1.2.6"
   pkg.md5sum "3b65295968799c8c9966083d0d9de0f0"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-json-schema.rb
+++ b/configs/components/rubygem-json-schema.rb
@@ -1,7 +1,7 @@
 component "rubygem-json-schema" do |pkg, settings, platform|
   pkg.version "2.8.0"
   pkg.md5sum "075b4034f57ee8ab900a92a8da45054a"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/json-schema-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/json-schema-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-json_pure.rb
+++ b/configs/components/rubygem-json_pure.rb
@@ -1,7 +1,7 @@
 component "rubygem-json_pure" do |pkg, settings, platform|
   pkg.version "2.1.0"
   pkg.md5sum "611938ea90a941ca220e1025262b0561"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/json_pure-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/json_pure-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -1,7 +1,7 @@
 component "rubygem-locale" do |pkg, settings, platform|
   pkg.version "2.1.2"
   pkg.md5sum "def1e89d1d3126a0c684d3b7b20d88d4"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/locale-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/locale-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-necromancer.rb
+++ b/configs/components/rubygem-necromancer.rb
@@ -1,7 +1,7 @@
 component "rubygem-necromancer" do |pkg, settings, platform|
   pkg.version "0.4.0"
   pkg.md5sum "f4e3986d55e53db3e8a47598e0e1db9c"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/necromancer-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/necromancer-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -9,7 +9,7 @@ component 'rubygem-nokogiri' do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.environment 'PATH', settings[:gem_path_env]
-    pkg.url "https://buildsources.delivery.puppetlabs.net/#{gemname}-#{pkg.get_version}-x64-mingw32.gem"
+    pkg.url "#{settings[:buildsources_url]}/#{gemname}-#{pkg.get_version}-x64-mingw32.gem"
     pkg.md5sum "fdcb75a394aa944dec24fdd8c183d741"
 
     pkg.install do

--- a/configs/components/rubygem-pastel.rb
+++ b/configs/components/rubygem-pastel.rb
@@ -1,7 +1,7 @@
 component "rubygem-pastel" do |pkg, settings, platform|
   pkg.version "0.7.1"
   pkg.md5sum "d18811c988aff85c25823b9e78074685"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/pastel-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/pastel-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -1,7 +1,7 @@
 component "rubygem-public_suffix" do |pkg, settings, platform|
   pkg.version "3.0.0"
   pkg.md5sum "787a298cfb1e4d9f39aa43a415d53e6f"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/public_suffix-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/public_suffix-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -1,7 +1,7 @@
 component "rubygem-text" do |pkg, settings, platform|
   pkg.version "1.3.1"
   pkg.md5sum "514c3d1db7a955fe793fc0cb149c164f"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/text-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/text-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-timers.rb
+++ b/configs/components/rubygem-timers.rb
@@ -1,7 +1,7 @@
 component "rubygem-timers" do |pkg, settings, platform|
   pkg.version "4.1.2"
   pkg.md5sum "2be9e4db59553d2aa6ae205c45e7a85b"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/timers-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/timers-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-tty-color.rb
+++ b/configs/components/rubygem-tty-color.rb
@@ -1,7 +1,7 @@
 component "rubygem-tty-color" do |pkg, settings, platform|
   pkg.version "0.4.2"
   pkg.md5sum "5eeee7ff49775b8569bea975f77ea94d"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-color-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/tty-color-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-tty-cursor.rb
+++ b/configs/components/rubygem-tty-cursor.rb
@@ -1,7 +1,7 @@
 component "rubygem-tty-cursor" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "44bde28174e9e0f1a7987a3e3ab87aab"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-cursor-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/tty-cursor-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-tty-prompt.rb
+++ b/configs/components/rubygem-tty-prompt.rb
@@ -1,7 +1,7 @@
 component "rubygem-tty-prompt" do |pkg, settings, platform|
   pkg.version "0.13.1"
   pkg.md5sum "033bca393ff6b7d67dd560cadf2be8c9"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-prompt-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/tty-prompt-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-tty-spinner.rb
+++ b/configs/components/rubygem-tty-spinner.rb
@@ -1,7 +1,7 @@
 component "rubygem-tty-spinner" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "36cad9c558a576415e58d316621422c6"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-spinner-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/tty-spinner-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-tty-which.rb
+++ b/configs/components/rubygem-tty-which.rb
@@ -1,7 +1,7 @@
 component "rubygem-tty-which" do |pkg, settings, platform|
   pkg.version "0.3.0"
   pkg.md5sum "633a1f4f8c6e15a26cb83e1be0b9f2ce"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/tty-which-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/tty-which-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-wisper.rb
+++ b/configs/components/rubygem-wisper.rb
@@ -1,7 +1,7 @@
 component "rubygem-wisper" do |pkg, settings, platform|
   pkg.version "2.0.0"
   pkg.md5sum "80deda8b4226106e88285373a8159f20"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/wisper-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:buildsources_url]}/wisper-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -6,7 +6,7 @@ platform "windows-2012r2-x64" do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
 

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -46,6 +46,9 @@ project "pdk" do |proj|
     proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
   end
 
+  proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+  proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+
   proj.setting(:ruby_version, "2.1.9")
   proj.setting(:bundler_version, "1.15.1")
   proj.setting(:mini_portile2_version, '2.3.0')
@@ -234,6 +237,6 @@ project "pdk" do |proj|
   # Here we rewrite public http urls to use our internal source host instead.
   # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
   # rewritten as
-  # http://buildsources.delivery.puppetlabs.net/openssl-1.0.0r.tar.gz
-  proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
+  # https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/openssl-1.0.0r.tar.gz
+  proj.register_rewrite_rule 'http', proj.buildsources_url
 end


### PR DESCRIPTION
This commit adds `artifactory_url` and `buildsources_url` settings and replaces buildsources.delivery.puppetlabs.net with Artifactory.