### PR TITLE
Autoshipping to PDK repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.13.1')
-gem 'packaging', '~> 0.6', :git => 'https://github.com/puppetlabs/packaging.git'
+gem 'packaging', :git => 'https://github.com/puppetlabs/packaging.git', :branch => '1.0.x'
 gem 'rake', '~> 12.0'
 
 #gem 'rubocop', "~> 0.34.2"

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -99,7 +99,7 @@ project "pdk" do |proj|
   proj.license "See components"
   proj.vendor "Puppet, Inc. <info@puppet.com>"
   proj.homepage "https://www.puppet.com"
-  proj.target_repo "PC1"
+  proj.target_repo "PDK"
 
   if platform.is_macos?
     proj.identifier "com.puppetlabs"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,10 +1,10 @@
 ---
 project: 'pdk'
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 # foss_platforms will be shipped to the nightly repos
 # foss_platforms:
-pe_platforms:
+foss_platforms:
   - el-6-x86_64
   - el-7-x86_64
   - osx-10.11-x86_64
@@ -23,6 +23,16 @@ osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
-apt_repo_name: 'PC1'
-yum_repo_name: 'PC1'
+apt_repo_name: 'PDK'
+yum_repo_name: 'PDK'
+repo_name: 'PDK'
 build_tar: FALSE
+staging_server: weth.delivery.puppetlabs.net
+msi_staging_server: 'weth.delivery.puppetlabs.com'
+tar_staging_server: 'weth.delivery.puppetlabs.net'
+dmg_staging_server: 'weth.delivery.puppetlabs.net'
+swix_staging_server: 'weth.delivery.puppetlabs.net'
+msi_staging_server: 'weth.delivery.puppetlabs.net'
+apt_signing_server: 'weth.delivery.puppetlabs.net'
+apt_signing_server: weth.delivery.puppetlabs.net
+yum_staging_server: weth.delivery.puppetlabs.net


### PR DESCRIPTION
This updates the PDK project to point to a 'PDK' repo
on the download servers.

Also updates to Packaging 1.0.x branch for updated shipping automation.