### PR TITLE
Revert "Autoshipping to PDK repos"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.13.1')
-gem 'packaging', :git => 'https://github.com/puppetlabs/packaging.git', :branch => '1.0.x'
+gem 'packaging', '~> 0.6', :git => 'https://github.com/puppetlabs/packaging.git'
 gem 'rake', '~> 12.0'
 
 #gem 'rubocop', "~> 0.34.2"

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -99,7 +99,7 @@ project "pdk" do |proj|
   proj.license "See components"
   proj.vendor "Puppet, Inc. <info@puppet.com>"
   proj.homepage "https://www.puppet.com"
-  proj.target_repo "PDK"
+  proj.target_repo "PC1"
 
   if platform.is_macos?
     proj.identifier "com.puppetlabs"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,10 +1,10 @@
 ---
 project: 'pdk'
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 # foss_platforms will be shipped to the nightly repos
 # foss_platforms:
-foss_platforms:
+pe_platforms:
   - el-6-x86_64
   - el-7-x86_64
   - osx-10.11-x86_64
@@ -23,16 +23,6 @@ osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
-apt_repo_name: 'PDK'
-yum_repo_name: 'PDK'
-repo_name: 'PDK'
+apt_repo_name: 'PC1'
+yum_repo_name: 'PC1'
 build_tar: FALSE
-staging_server: weth.delivery.puppetlabs.net
-msi_staging_server: 'weth.delivery.puppetlabs.com'
-tar_staging_server: 'weth.delivery.puppetlabs.net'
-dmg_staging_server: 'weth.delivery.puppetlabs.net'
-swix_staging_server: 'weth.delivery.puppetlabs.net'
-msi_staging_server: 'weth.delivery.puppetlabs.net'
-apt_signing_server: 'weth.delivery.puppetlabs.net'
-apt_signing_server: weth.delivery.puppetlabs.net
-yum_staging_server: weth.delivery.puppetlabs.net


### PR DESCRIPTION
Reverts puppetlabs/pdk-vanagon#95, as it is assumed to be breaking the build:

```
bundler: failed to load command: repo (/tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bin/repo)
RuntimeError: createrepo tool not found...exiting
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/lib/packaging/util/tool.rb:28:in `find_tool'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/lib/packaging/util/tool.rb:9:in `check_tool'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/lib/packaging/rpm/repo.rb:26:in `repo_creation_command'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/lib/packaging/rpm/repo.rb:208:in `create_remote_repos'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/tasks/rpm_repos.rake:16:in `block (3 levels) in <top (required)>'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:251:in `block in execute'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:251:in `each'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:251:in `execute'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:195:in `block in invoke_with_call_chain'
  /usr/local/rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:188:in `invoke_with_call_chain'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/rake-12.3.0/lib/rake/task.rb:181:in `invoke'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bundler/gems/packaging-84c019ede3f1/lib/packaging/util/rake_utils.rb:29:in `invoke_task'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/gems/vanagon-0.13.1/bin/repo:24:in `<top (required)>'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bin/repo:23:in `load'
  /tmp/jenkins/workspace/platform_pdk_pkg-van-repo_master/.bundle/gems/ruby/2.3.0/bin/repo:23:in `<top (required)>'
Build step 'Execute shell' marked build as failure
```
from https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_pdk_pkg-van-repo_master/20