### PR TITLE
(maint) Add Fedora 26 platform

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -11,7 +11,9 @@ component "openssl" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.build_requires "runtime"
   elsif platform.is_linux?
-    pkg.build_requires 'pl-binutils'
+    unless platform.is_fedora? && platform.os_version.delete('f').to_i >= 26
+      pkg.build_requires 'pl-binutils'
+    end
     pkg.build_requires 'pl-gcc'
   end
 

--- a/configs/platforms/fedora-f26-x86_64.rb
+++ b/configs/platforms/fedora-f26-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-f26-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-26-x86_64"
+end


### PR DESCRIPTION
This commit adds the ability to build PDK for Fedora 26.
It is based off the Puppet Agent configuration.