### PR TITLE
(maint) Add nonfinal_repo_name

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -24,6 +24,7 @@ osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
 repo_name: 'puppet5'
+nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE
 staging_server: 'weth.delivery.puppetlabs.net'
 msi_staging_server: 'weth.delivery.puppetlabs.com'


### PR DESCRIPTION
This commit sets the `nonfinal_repo_name` to 'puppet5-nightly' so that nightly builds land in the correct repos.