### PR TITLE
(PDK-787) Cache various puppet gems and their dependencies

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -1,0 +1,64 @@
+component "puppet-forge-api" do |pkg, settings, platform|
+  pkg.ref "master"
+  pkg.url "git@github.com:puppetlabs/puppet-forge-api.git"
+
+  pkg.build_requires "pdk-runtime"
+
+  # We need a few different things that come from the Forge API codebase so we do it all in this component.
+
+  pkg.build do
+    # Install puppet-gem versions based on a mapping stored in the Forge API code
+
+    gem_source = "https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems"
+    puppet_cachedir = File.join(settings[:privatedir], 'puppet', 'ruby')
+
+    # TODO: update this to point to specific ruby versions
+    gem_bins = {
+      '2.1.0' => File.join(settings[:ruby_bindir], (platform.is_windows? ? 'gem.bat' : 'gem')),
+      '2.4.0' => File.join(settings[:ruby_bindir], (platform.is_windows? ? 'gem.bat' : 'gem')),
+    }
+
+    # TODO: get this mapping from forge api code (or wget from Forge itself)
+    puppet_rubyapi_versions = {
+      '4.7.1' => '2.1.0',
+      '4.8.2' => '2.1.0',
+      '4.9.4' => '2.1.0',
+      '4.10.10' => '2.1.0',
+      '5.0.1' => '2.4.0',
+      '5.1.0' => '2.4.0',
+      '5.2.0' => '2.4.0',
+      '5.3.5' => '2.4.0',
+      '5.4.0' => '2.4.0',
+    }
+
+    build_commands = []
+
+    build_commands += puppet_rubyapi_versions.collect do |pupver, rubyapi|
+      "#{gem_bins[rubyapi]} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, rubyapi)} puppet --version #{pupver}"
+    end
+
+    find_in_cache_with_regex = '/usr/bin/find '
+    find_in_cache_with_regex << '-E ' if platform.is_macos?
+    find_in_cache_with_regex << puppet_cachedir << ' '
+    find_in_cache_with_regex << '-regextype posix-extended ' unless platform.is_macos?
+    find_in_cache_with_regex << '-regex '
+
+    # The puppet gem has files in it's 'spec' directory with very long paths which
+    # bump up against MAX_PATH on Windows. They also unncessarily bloat the package
+    # size. Since the 'spec' directory is not required at runtime, we just purge it
+    # before attempting to package.
+    build_commands << "#{find_in_cache_with_regex} '.*/puppet-[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+[^/]*/spec/.*' -delete"
+
+    # We also purge the included man pages.
+    build_commands << "#{find_in_cache_with_regex} '.*/puppet-[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+[^/]*/man/.*' -delete"
+
+    # We don't need the binaries or cached .gem packages either
+    build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/bin/.*' -delete"
+    build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/cache/.*\\.gem' -delete"
+
+    build_commands
+  end
+
+  # Cache the task metadata schema.
+  pkg.install_file('app/static/schemas/task.json', File.join(settings[:cachedir], 'task.json'))
+end

--- a/configs/components/task-schema.rb
+++ b/configs/components/task-schema.rb
@@ -1,7 +1,0 @@
-component "task-schema" do |pkg, settings, platform|
-  pkg.ref "master"
-  pkg.url "git@github.com:puppetlabs/puppet-forge-api.git"
-  pkg.dirname "puppet-forge-api"
-
-  pkg.install_file('app/static/schemas/task.json', File.join(settings[:cachedir], 'task.json'))
-end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -200,8 +200,8 @@ project "pdk" do |proj|
   # Batteries included copies of module template and required gems
   proj.component "pdk-templates"
 
-  # Cache a copy of the task.json schema file
-  proj.component "task-schema"
+  # Cache puppet gems, task metadata schema, etc.
+  proj.component "puppet-forge-api"
 
   # Set up PATH on posix platforms
   proj.component "shellpath" unless platform.is_windows?


### PR DESCRIPTION
I got the bundler invocation figured out to prevent it from installing duplicates copies of puppet+deps into the generic gem cache, but it's commented out right now to prevent breaking the builds (or forcing PDK to install puppet at runtime). Once PDK knows where to look for the puppet gems we can re-enable that (https://github.com/puppetlabs/pdk-vanagon/pull/121/files#diff-0fa2fe03c607920e7b6b10aaf45f0c56R66) and reduce the package size a bit.