### PR TITLE
(PDK-828) Cache pe_versions.json from puppet-forge-api codebase

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -7,8 +7,7 @@ component "puppet-forge-api" do |pkg, settings, platform|
   # We need a few different things that come from the Forge API codebase so we do it all in this component.
 
   pkg.build do
-    # Install puppet-gem versions based on a mapping stored in the Forge API code
-
+    # Cache specific versions of the puppet gem
     gem_source = "https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems"
     puppet_cachedir = File.join(settings[:privatedir], 'puppet', 'ruby')
 
@@ -18,7 +17,6 @@ component "puppet-forge-api" do |pkg, settings, platform|
       '2.4.0' => File.join(settings[:ruby_bindir], (platform.is_windows? ? 'gem.bat' : 'gem')),
     }
 
-    # TODO: get this mapping from forge api code (or wget from Forge itself)
     puppet_rubyapi_versions = {
       '4.7.1' => '2.1.0',
       '4.8.2' => '2.1.0',
@@ -52,12 +50,14 @@ component "puppet-forge-api" do |pkg, settings, platform|
     # We also purge the included man pages.
     build_commands << "#{find_in_cache_with_regex} '.*/puppet-[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+[^/]*/man/.*' -delete"
 
-    # We don't need the binaries or cached .gem packages either
-    build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/bin/.*' -delete"
+    # We don't need the cached .gem packages either
     build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/cache/.*\\.gem' -delete"
 
     build_commands
   end
+
+  # Cache the PE to puppet version mapping.
+  pkg.install_file('lib/pe_versions.json', File.join(settings[:cachedir], 'pe_versions.json'))
 
   # Cache the task metadata schema.
   pkg.install_file('app/static/schemas/task.json', File.join(settings[:cachedir], 'task.json'))


### PR DESCRIPTION
Dropping (for now at least) the idea of resolving what puppets to cache at build-time. I think it introduces too much complexity (and non-reproducibility) to the build process.

But this does bring the pe_versions.json file from the forge-api codebase into the cachedir at build time.

With this approach we would just PR changes to the `puppet_rubyapi_versions` mapping data structure in this file when we want to add a new puppet gem to the cache. We could move that mapping to a JSON file down the road to make auto-promotion easier.