### PR TITLE
(maint) Update cri to 2.10.1

### DIFF
--- a/configs/components/rubygem-cri.rb
+++ b/configs/components/rubygem-cri.rb
@@ -1,6 +1,6 @@
 component "rubygem-cri" do |pkg, settings, platform|
-  pkg.version "2.9.1"
-  pkg.md5sum "a69b95364558623133d15ad25a7be46a"
+  pkg.version "2.10.1"
+  pkg.md5sum "3b270cde9529f1d738850b731c20f343"
   pkg.url "#{settings[:buildsources_url]}/cri-#{pkg.get_version}.gem"
 
   pkg.build_requires "pdk-runtime"


### PR DESCRIPTION
This update is to support https://github.com/puppetlabs/pdk/pull/466