### PR TITLE
(FIXUP) Avoid replacing the bundle.bat wrappers on windows

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -75,8 +75,8 @@ component "pdk-templates" do |pkg, settings, platform|
     # inside the project cachedir.
     build_commands << "pushd #{mod_name} && GEM_PATH=\"#{gem_path_with_puppet_cache}\" GEM_HOME=\"#{ruby_cachedir}\" #{settings[:host_bundle]} install && popd"
 
-    # Install bundler and other special deps into the gem cache
-    build_commands << "GEM_HOME=#{ruby_cachedir} #{settings[:gem_install]} ../bundler-#{settings[:bundler_version]}.gem"
+    # Install bundler into the gem cache
+    build_commands << "GEM_HOME=#{ruby_cachedir} #{settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler_version]}.gem"
 
     if platform.is_windows?
       # The puppet gem has files in it's 'spec' directory with very long paths which
@@ -119,7 +119,7 @@ component "pdk-templates" do |pkg, settings, platform|
       build_commands << "pushd #{local_mod_name} && PUPPET_GEM_VERSION=\"#{local_settings[:latest_puppet]}\" GEM_PATH=\"#{local_gem_path}\" GEM_HOME=\"#{local_ruby_cachedir}\" #{local_settings[:host_bundle]} install && popd"
 
       # Install bundler itself into the gem cache for this ruby
-      build_commands << "GEM_HOME=#{local_ruby_cachedir} #{local_settings[:gem_install]} --force ../bundler-#{settings[:bundler_version]}.gem"
+      build_commands << "GEM_HOME=#{local_ruby_cachedir} #{local_settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler_version]}.gem"
 
       # Prepend native gem installation commands for this ruby
       pre_build_commands << "GEM_HOME=#{local_ruby_cachedir} #{local_settings[:gem_install]} ../mini_portile2-#{settings[:mini_portile2_version]}.gem"

--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -42,12 +42,16 @@ component "puppet-forge-api" do |pkg, settings, platform|
 
     build_commands = []
 
+    # Make backups of the gem and bundler wrapper batch files...
+    build_commands << "cp #{gem_bins['2.1.0']} #{gem_bins['2.1.0']}.bak" if platform.is_windows?
+    build_commands << "cp #{bundle_bins['2.1.0']} #{bundle_bins['2.1.0']}.bak" if platform.is_windows?
+
     # Update gem command on ruby 2.1.9 to latest to avoid getting pre-release facter gems?
     build_commands << "#{gem_bins['2.1.0']} update --system --no-document"
 
-    # Replace the gem and bundler wrapper batch files...
-    build_commands << "cp #{gem_bins['2.4.0']} #{gem_bins['2.1.0']}" if platform.is_windows?
-    build_commands << "cp #{bundle_bins['2.4.0']} #{bundle_bins['2.1.0']}" if platform.is_windows?
+    # ...replace the gem and bundler wrapper batch files file the backups we made.
+    build_commands << "mv #{gem_bins['2.1.0']}.bak #{gem_bins['2.1.0']}" if platform.is_windows?
+    build_commands << "mv #{bundle_bins['2.1.0']}.bak #{bundle_bins['2.1.0']}" if platform.is_windows?
 
     build_commands += puppet_rubyapi_versions.collect do |pupver, rubyapi|
       "#{gem_bins[rubyapi]} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, rubyapi)} puppet:#{pupver} --platform #{puppet_gem_platform}"


### PR DESCRIPTION
Haven't been able to test this fully yet due to vmpooler running out of windows images.