### PR TITLE
(PDK-969) rewrite gem .bat wrappers for additional rubies

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -75,6 +75,14 @@ component "puppet-forge-api" do |pkg, settings, platform|
     # We don't need the cached .gem packages either
     build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/cache/.*\\.gem' -delete"
 
+    if platform.is_windows?
+      batch_rewrites = [
+        's|ProgramFiles64Folder|Program Files|g',
+        's|PuppetLabs|Puppet Labs|g',
+      ]
+      build_commands << "/usr/bin/find #{puppet_cachedir} -name '*.bat' -exec sed -i '#{batch_rewrites.join(' ; ')}' {} \\;"
+    end
+
     build_commands
   end
 

--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -4,6 +4,8 @@ component "puppet-forge-api" do |pkg, settings, platform|
 
   pkg.build_requires "pdk-runtime"
 
+  pkg.add_source('file://resources/files/windows/ruby_gem_wrapper.bat') if platform.is_windows?
+
   # We need a few different things that come from the Forge API codebase so we do it all in this component.
 
   pkg.build do
@@ -76,11 +78,8 @@ component "puppet-forge-api" do |pkg, settings, platform|
     build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/cache/.*\\.gem' -delete"
 
     if platform.is_windows?
-      batch_rewrites = [
-        's|ProgramFiles64Folder|Program Files|g',
-        's|PuppetLabs|Puppet Labs|g',
-      ]
-      build_commands << "/usr/bin/find #{puppet_cachedir} -name '*.bat' -exec sed -i '#{batch_rewrites.join(' ; ')}' {} \\;"
+      wrapper_path = File.join('..', 'ruby_gem_wrapper.bat')
+      build_commands << "/usr/bin/find #{puppet_cachedir} -name '*.bat' -exec cp #{wrapper_path} {} \\;"
     end
 
     build_commands

--- a/resources/files/windows/ruby_gem_wrapper.bat
+++ b/resources/files/windows/ruby_gem_wrapper.bat
@@ -1,0 +1,11 @@
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
+GOTO :EOF
+:WinNT
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*


### PR DESCRIPTION
Rewrites paths in the rubygems generated batch files so that `C:\ProgramFiles64Folder\PuppetLabs\` becomes `C:\Program Files\Puppet Labs\`