### PR TITLE
(CPR-391) Fedora packages have odd distro tag

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -11,8 +11,8 @@ component "pdk-templates" do |pkg, settings, platform|
   pkg.build_requires "puppet-forge-api"
 
   platforms_without_plgcc = %w[
-    fedora-f26-x86_64
-    fedora-f27-x86_64
+    fedora-26-x86_64
+    fedora-27-x86_64
     ubuntu-18.04-amd64
   ]
 

--- a/configs/platforms/fedora-26-x86_64.rb
+++ b/configs/platforms/fedora-26-x86_64.rb
@@ -1,4 +1,4 @@
-platform "fedora-f26-x86_64" do |plat|
+platform "fedora-26-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
@@ -7,4 +7,5 @@ platform "fedora-f26-x86_64" do |plat|
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-26-x86_64"
+  plat.dist "fc26"
 end

--- a/configs/platforms/fedora-27-x86_64.rb
+++ b/configs/platforms/fedora-27-x86_64.rb
@@ -1,4 +1,4 @@
-platform "fedora-f27-x86_64" do |plat|
+platform "fedora-27-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
@@ -7,4 +7,5 @@ platform "fedora-f27-x86_64" do |plat|
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-27.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-27-x86_64"
+  plat.dist "fc27"
 end


### PR DESCRIPTION
This commit updates the fedora platform configs to not use the 'f' prefix in
versions and, instead, use 'fc<version>' as the dist tag, which is standard for
fedora packages.