### PR TITLE
(PDK-950) Adds some pre-compiled beaker depends

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -39,8 +39,22 @@ component "puppet-forge-api" do |pkg, settings, platform|
       '5.4.0'   => '2.4.0',
       '5.5.1'   => '2.4.0',
     }
+    pdk_ruby_versions = puppet_rubyapi_versions.values.uniq
 
     puppet_gem_platform = platform.is_windows? ? 'x64-mingw32' : 'ruby'
+
+    gem_install = lambda do |ruby_version, gem, version|
+      [
+        gem_bins[ruby_version],
+        'install',
+        '--clear-sources',
+        "--source #{gem_source}",
+        '--no-document',
+        "--install-dir #{File.join(puppet_cachedir, ruby_version)}",
+        "#{gem}:#{version}",
+        "--platform #{puppet_gem_platform}",
+      ].join(' ')
+    end
 
     build_commands = []
 
@@ -56,7 +70,7 @@ component "puppet-forge-api" do |pkg, settings, platform|
     build_commands << "mv #{bundle_bins['2.1.0']}.bak #{bundle_bins['2.1.0']}" if platform.is_windows?
 
     build_commands += puppet_rubyapi_versions.collect do |pupver, rubyapi|
-      "#{gem_bins[rubyapi]} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, rubyapi)} puppet:#{pupver} --platform #{puppet_gem_platform}"
+      gem_install.call(rubyapi, 'puppet', pupver)
     end
 
     find_in_cache_with_regex = '/usr/bin/find '
@@ -86,25 +100,25 @@ component "puppet-forge-api" do |pkg, settings, platform|
       # Install the natively built json-1.8.6 gem into the 2.4.0 cache.
       # The 2.1.0 cache doesn't need it because it can resolve to the vendored
       # 1.8.1 version of json in ruby 2.1.9.
-      build_commands << "#{gem_bins['2.4.0']} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, '2.4.0')} json:1.8.6 --platform #{puppet_gem_platform}"
+      build_commands << gem_install.call('2.4.0', 'json', '1.8.6')
 
-      # Byebug requires special treatment b/c the cross compiled into a fat gem
-      ['2.4', '2.1'].each do |rubyapi|
-        build_commands << "#{gem_bins["#{rubyapi}.0"]} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, "#{rubyapi}.0")} byebug:9.0.6 --platform #{puppet_gem_platform}"
-        byebug_libdir = File.join(puppet_cachedir, "#{rubyapi}.0", "gems", "byebug-9.0.6-x64-mingw32", "lib", "byebug")
-        build_commands << "cp #{File.join(byebug_libdir, rubyapi, "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}"
-      end
-
-      # Add the remaining beaker dependencies that have been natively compiled
-      # and repackaged.
       beaker_native_deps = {
         'oga':     '2.15',
         'ruby-ll': '2.1.2'
       }
 
-      ['2.1.0', '2.4.0'].each do |rubyapi|
+      pdk_ruby_versions.each do |rubyapi|
+        # Byebug requires special treatment b/c the cross compiled into a fat gem
+        byebug_libdir = File.join(puppet_cachedir, rubyapi, "gems", "byebug-9.0.6-x64-mingw32", "lib", "byebug")
+        build_commands += [
+          gem_install.call(rubyapi, 'byebug', '9.0.6'),
+          "cp #{File.join(byebug_libdir, rubyapi.split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}",
+        ]
+
+        # Add the remaining beaker dependencies that have been natively compiled
+        # and repackaged.
         build_commands += beaker_native_deps.collect do |gem, ver|
-          "#{gem_bins[rubyapi]} install --clear-sources --source #{gem_source} --no-document --install-dir #{File.join(puppet_cachedir, rubyapi)} #{gem}:#{ver} --platform #{puppet_gem_platform}"
+          gem_install.call(rubyapi, gem, ver)
         end
       end
     end


### PR DESCRIPTION
This PR will add the beaker dependencies that require native compilation to the pdk gem cache. The gems have been natively built and uploaded to artifactory. The JSON gem is only needed on Ruby 2.4.0, since the vendored JSON 1.8.1 with Ruby 2.1.9 should satisfy the version requirement from beaker-aws. The extra logic for the byebug gem is because I had to build a fat gem that included the built extensions for each respective version of Ruby, and also add logic to the build script to put the correct extension into the right directory.