### PR TITLE
(maint) Removes puppet-strings from experimental gems list.

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -72,7 +72,6 @@ component "pdk-templates" do |pkg, settings, platform|
     build_commands << "echo 'gem \"puppet-debugger\",                            require: false' >> #{mod_name}/Gemfile"
     build_commands << "echo 'gem \"guard\",                                      require: false' >> #{mod_name}/Gemfile"
     build_commands << "echo 'gem \"listen\",                                     require: false' >> #{mod_name}/Gemfile"
-    build_commands << "echo 'gem \"puppet-strings\",                             require: false' >> #{mod_name}/Gemfile"
     build_commands << "echo 'gem \"codecov\",                                    require: false' >> #{mod_name}/Gemfile"
     build_commands << "echo 'gem \"license_finder\",                             require: false' >> #{mod_name}/Gemfile"
 


### PR DESCRIPTION
puppet-strings has been added to the meta gems, so they will be included in the PDK cache due to that.