### PR TITLE
(PDK-1087) Fix gem wrappers in module cache

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -28,6 +28,7 @@ component "pdk-templates" do |pkg, settings, platform|
     pdk_bin = File.join(settings[:ruby_bindir], 'pdk')
     ruby_cachedir = File.join(settings[:cachedir], 'ruby', settings[:ruby_api])
     puppet_cachedir = File.join(settings[:privatedir], 'puppet', 'ruby')
+    gem_wrapper_path = File.join('..', 'ruby_gem_wrapper.bat')
 
     gem_path_with_puppet_cache = [
       File.join(settings[:privatedir], 'ruby', settings[:ruby_version], 'lib', 'ruby', 'gems', settings[:ruby_api]),
@@ -87,6 +88,8 @@ component "pdk-templates" do |pkg, settings, platform|
       # bump up against MAX_PATH on Windows. Since the 'spec' directory is not required
       # at runtime, we just purge it before attempting to package.
       build_commands << "/usr/bin/find #{ruby_cachedir} -regextype posix-extended -regex '.*/puppet-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^/]*/spec/.*' -delete"
+
+      build_commands << "/usr/bin/find #{ruby_cachedir} -name '*.bat' -exec cp #{gem_wrapper_path} {} \\;"
     end
 
     # Bundle install for each additional ruby version as well, in case we need different versions for a different ruby.
@@ -133,6 +136,7 @@ component "pdk-templates" do |pkg, settings, platform|
         # bump up against MAX_PATH on Windows. Since the 'spec' directory is not required
         # at runtime, we just purge it before attempting to package.
         build_commands << "/usr/bin/find #{local_ruby_cachedir} -regextype posix-extended -regex '.*/puppet-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^/]*/spec/.*' -delete"
+        build_commands << "/usr/bin/find #{local_ruby_cachedir} -name '*.bat' -exec cp #{gem_wrapper_path} {} \\;"
 
         pre_build_commands << "GEM_HOME=#{local_ruby_cachedir} #{local_settings[:gem_install]} ../nokogiri-#{settings[:nokogiri_version]}-x64-mingw32.gem"
       end


### PR DESCRIPTION
As a result of PDK-1073, there are now other gems that appear in the PATH, which means they also need the fixed wrapper `.bat` files on Windows in order to be called via `pdk bundle exec`