### PR TITLE
(PDK-1056, PDK-1141) Adds Ruby 2.5.1 and Puppet 6.0.0 to PDK packaging

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -128,8 +128,9 @@ component "pdk-templates" do |pkg, settings, platform|
       build_commands << "echo 'gem \"puppet-strings\",                             require: false' >> #{local_mod_name}/Gemfile"
       build_commands << "echo 'gem \"codecov\",                                    require: false' >> #{local_mod_name}/Gemfile"
       build_commands << "echo 'gem \"license_finder\",                             require: false' >> #{local_mod_name}/Gemfile"
+      build_commands << "echo 'gem \"nokogiri\", \"<= 1.8.2\",                     require: false' >> #{local_mod_name}/Gemfile"
 
-      # Istall all the deps into the package cachedir.
+      # Install all the deps into the package cachedir.
       build_commands << "pushd #{local_mod_name} && PUPPET_GEM_VERSION=\"#{local_settings[:latest_puppet]}\" GEM_PATH=\"#{local_gem_path}\" GEM_HOME=\"#{local_ruby_cachedir}\" #{local_settings[:host_bundle]} install && popd"
 
       # Install bundler itself into the gem cache for this ruby

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -1,6 +1,6 @@
 project "pdk" do |proj|
   # Inherit a bunch of shared settings from pdk-runtime config
-  proj.setting(:pdk_runtime_version, '201808080')
+  proj.setting(:pdk_runtime_version, '201809180')
   proj.inherit_settings 'pdk-runtime', 'git://github.com/puppetlabs/puppet-runtime', proj.pdk_runtime_version
 
   proj.description "Puppet Development Kit"


### PR DESCRIPTION
Adds Puppet 6 and Ruby 2.5.1 to the PDK cache. Also adds Nokogiri to the cache for more than just Windows and for all ruby versions, since we can't assume that modules that use beaker are going to be defaulted to Ruby 2.4.4.