### PR TITLE
(maint) Update batch file shims on Windows for all rubies.

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -40,7 +40,6 @@ component "puppet-forge-api" do |pkg, settings, platform|
       '5.5.1'   => '2.4.0',
       '6.0.0'   => '2.5.0',
     }
-    pdk_ruby_versions = puppet_rubyapi_versions.values.uniq
 
     puppet_gem_platform = platform.is_windows? ? 'x64-mingw32' : 'ruby'
 
@@ -95,27 +94,31 @@ component "puppet-forge-api" do |pkg, settings, platform|
     build_commands << "#{find_in_cache_with_regex} '.*/[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+/cache/.*\\.gem' -delete"
 
     if platform.is_windows?
-      wrapper_path = File.join('..', 'ruby_gem_wrapper.bat')
-      build_commands << "/usr/bin/find #{puppet_cachedir} -name '*.bat' -exec cp #{wrapper_path} {} \\;"
-
       # Add beaker dependencies
       beaker_native_deps = {
         'oga':     '2.15',
         'ruby-ll': '2.1.2',
       }
 
-      pdk_ruby_versions.each do |rubyapi|
+      settings[:additional_rubies]&.each do |rubyver, local_settings|
+        # Update batch file shims for each ruby version.
+        wrapper_path = File.join('..', 'ruby_gem_wrapper.bat')
+        local_ruby_bindir = File.join(settings[:privatedir], 'ruby', rubyver, 'bin')
+
+        build_commands << "/usr/bin/find #{puppet_cachedir} -name '*.bat' -exec cp #{wrapper_path} {} \\;"
+        build_commands << "/usr/bin/find #{local_ruby_bindir} -name '*.bat' -exec cp #{wrapper_path} {} \\;"
+
         # Byebug requires special treatment b/c the cross compiled into a fat gem
-        byebug_libdir = File.join(puppet_cachedir, rubyapi, "gems", "byebug-9.0.6-x64-mingw32", "lib", "byebug")
+        byebug_libdir = File.join(puppet_cachedir, local_settings[:ruby_api], "gems", "byebug-9.0.6-x64-mingw32", "lib", "byebug")
         build_commands += [
-          gem_install.call(rubyapi, 'byebug', '9.0.6'),
-          "cp #{File.join(byebug_libdir, rubyapi.split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}",
+          gem_install.call(local_settings[:ruby_api], 'byebug', '9.0.6'),
+          "cp #{File.join(byebug_libdir, local_settings[:ruby_api].split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}",
         ]
 
         # Add the remaining beaker dependencies that have been natively compiled
         # and repackaged.
         build_commands += beaker_native_deps.collect do |gem, ver|
-          gem_install.call(rubyapi, gem, ver)
+          gem_install.call(local_settings[:ruby_api], gem, ver)
         end
       end
     end


### PR DESCRIPTION
The batch files need to be updated in both the shared cache and in the private ruby bins.