### PR TITLE
(maint) Update `repo_name` and `nonfinal_repo_name` for puppet6

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -21,8 +21,8 @@ osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
-repo_name: 'puppet5'
-nonfinal_repo_name: 'puppet5-nightly'
+repo_name: 'puppet6'
+nonfinal_repo_name: 'puppet6-nightly'
 build_tar: FALSE
 staging_server: 'weth.delivery.puppetlabs.net'
 msi_staging_server: 'weth.delivery.puppetlabs.com'


### PR DESCRIPTION
This commit updates the `repo_name` and `nonfinal_repo_name` params to
`puppet6` and `puppet6-nightly`, respectively. These params are used by the
packaging repo to determine where to ship packages. This is especially
necessary for shipping nightly builds to the most-current repo.