### PR TITLE
(PDK-1370) Create tarballs of ruby environment for Windows

### DIFF
--- a/configs/components/pdk-create-ruby-tarballs.rb
+++ b/configs/components/pdk-create-ruby-tarballs.rb
@@ -1,0 +1,42 @@
+component "pdk-create-ruby-tarballs" do |pkg, settings, platform|
+  # Can only create the tarballs AFTER all of them gemfiles have been pruned
+  pkg.build_requires 'gem-prune'
+
+  # We only create the tarballs on Windows right now
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/install-tarballs/extract_all.rb")
+    pkg.directory "#{settings[:datadir]}/install-tarballs"
+    # Unlike other examples, where the path would be '../<file>' we use the current workding directory.  This is because
+    # even though we add a source as above, because it is not a gem or tar etc., the component has nothing to extract therefore
+    # we don't end up in a component directory
+    pkg.install_file "extract_all.rb", "#{settings[:datadir]}/install-tarballs/extract_all.rb"
+
+    pkg.build do
+      build_commands = []
+
+      # Create the destination directory incase it doesn't exist already
+      build_commands << "mkdir -p #{settings[:datadir]}/install-tarballs"
+      build_commands << "pushd #{settings[:install_root]}"
+
+      delete_dirs = []
+      # Tar up the base ruby. This will exclude the ruby runtime as we need that for the extraction
+      dirs = ["private/puppet/ruby/#{settings[:ruby_api]}", "share/cache/ruby/#{settings[:ruby_api]}"]
+      build_commands << "#{platform.tar} --create --gzip --file share/install-tarballs/ruby-#{settings[:ruby_version]}.tgz --directory=. " + dirs.join(" ")
+      delete_dirs.concat(dirs)
+
+      settings[:additional_rubies].each do |_, local_settings|
+        dirs = ["private/puppet/ruby/#{local_settings[:ruby_api]}", "share/cache/ruby/#{local_settings[:ruby_api]}", "private/ruby/#{local_settings[:ruby_version]}"]
+        # Tar up the rest. This will include the ruby runtime as well
+        build_commands << "#{platform.tar} --create --gzip --file share/install-tarballs/ruby-#{local_settings[:ruby_version]}.tgz --directory=. " + dirs.join(" ")
+        delete_dirs.concat(dirs)
+      end
+
+      # We delete the source directories AFTER tarring to make debugging easier if something goes wrong.
+      delete_dirs.each { |dir| build_commands << "rm -rf #{dir}"}
+
+      build_commands << "popd"
+
+      build_commands
+    end
+  end
+end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -139,6 +139,8 @@ project "pdk" do |proj|
 
   proj.component "gem-prune"
 
+  proj.component "pdk-create-ruby-tarballs"
+
   # Set up PATH on posix platforms
   proj.component "shellpath" unless platform.is_windows?
 

--- a/resources/files/install-tarballs/extract_all.rb
+++ b/resources/files/install-tarballs/extract_all.rb
@@ -1,0 +1,70 @@
+# Idea from https://stackoverflow.com/questions/856891/unzip-zip-tar-tag-gz-files-with-ruby
+# Altered using https://github.com/puppetlabs/puppet/blob/983154f7e29a2a50d416d889a6fed012b9b12399/lib/puppet/module_tool/tar/mini.rb
+#
+# WARNING - This extraction blindly assumes the tarballs are sane and correct. Unlike the `.../module_tool/tar/mini.rb` implementation, this
+# script does not do any checks:
+# - Symlinks within the tar will throw an error
+# - We assume that all files in the tar have relative paths. If there is an absolute path in the tarball it will 'escape' the intended extract directory
+# - Avoids extra disk IO (e.g. expand_path) as the tarballs will have 30,000+ files inside
+
+require 'fileutils'
+require 'rubygems/package'
+require 'zlib'
+
+TAR_LONGLINK = '././@LongLink'
+
+def logmessage(message)
+  puts message if ENV['PDK_DEBUG']
+end
+
+# From lib/puppet/module_tool/tar/mini.rb
+EXECUTABLE = 0755
+NOT_EXECUTABLE = 0644
+USER_EXECUTE = 0100
+
+def sanitized_mode(old_mode)
+  # From lib/puppet/module_tool/tar/mini.rb
+  old_mode & USER_EXECUTE != 0 ? EXECUTABLE : NOT_EXECUTABLE
+end
+
+def unpack(sourcefile, destdir, _)
+  Gem::Package::TarReader.new( Zlib::GzipReader.open sourcefile ) do |tar|
+    dest = nil
+    tar.each do |entry|
+      if entry.full_name == TAR_LONGLINK
+        dest = File.join destdir, entry.read.strip
+        next
+      end
+      dest ||= File.join destdir, entry.full_name
+      if entry.directory? || (entry.header.typeflag == '' && entry.full_name.end_with?('/'))
+        # Due to the size of the tarballs, logging consumes a ton of time. Just ignore it for now
+        # logmessage("dir #{dest}")
+        File.delete dest if File.file? dest
+        # set_dir_mode! from mini.rb will always set this to EXECUTABLE so just use that - ref
+        FileUtils.mkdir_p dest, :mode => EXECUTABLE, :verbose => false
+      elsif entry.file? || (entry.header.typeflag == '' && !entry.full_name.end_with?('/'))
+        # Due to the size of the tarballs, logging consumes a ton of time. Just ignore it for now
+        # logmessage "file #{dest}"
+        FileUtils.rm_rf dest if File.directory? dest
+        File.open dest, "wb" do |f|
+          f.print entry.read
+        end
+        FileUtils.chmod sanitized_mode(entry.header.mode), dest, :verbose => false
+      # There should be NO symlinks on our tarballs so just ignore them
+      # elsif entry.header.typeflag == '2' #Symlink!
+      #   File.symlink entry.header.linkname, dest
+      else
+        logmessage("Unkown tar entry: #{entry.full_name} type: #{entry.header.typeflag}.")
+      end
+      dest = nil
+    end
+  end
+end
+
+script_dir = __dir__
+dest_dir = File.expand_path(File.join(script_dir, '..', '..'))
+
+Dir.glob(File.join(script_dir, '*.tgz')) do |targz_filename|
+  logmessage("Extracting #{targz_filename} to #{dest_dir} ...")
+  unpack(targz_filename, dest_dir, nil)
+end


### PR DESCRIPTION
Previously the PDK build process created 50,000+ files which causes issues with
MSI installation and uninstallation times.  This commit is the start of a
process to decrease install time by generating less files.

This commit:
* Adds a new component called pdk-create-ruby-tarballs which is responsible for
  taking a PDK installation files and compressing the ruby environments and
  their respective gem and puppet gem caches.  Note that the ruby environment
  which PDK runs in, at this time Ruby 2.4 is not compressed as it is required
  for the decompression step.
* The new pdk-create-ruby-tarballs component will only run on Windows builds.
  Later commits may remove this restriction.
* Adds a new file the to installation media called `extract_all.rb`. This small
  script is responsible for extracting the tarballs back to their original
  locations.  Later commits will use this ruby file, during installation time,
  to "re-hydrate" the entire PDK ruby and gem files.

For the moment this commit is only responsible for creating the tarballs and
adding the extraction script.

Note - Compresses files are removed from the installation source media which
resulted in over 30,000 files being moved into the compressed tarballs.