### PR TITLE
(PDK-1378) Promote pdk-runtime to include change to use /etc/gitconfig

### DIFF
--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -23,8 +23,6 @@ platform 'osx-10.14-x86_64' do |plat|
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
-  # Need to use 1012 image until PA-2334 is resolved to add Homebrew toolchain
-  # changes to 10.13 and 10.14.
-  plat.vmpooler_template 'osx-1012-x86_64'
+  plat.vmpooler_template 'osx-1014-x86_64'
   plat.output_dir File.join('apple', '10.14', 'PC1', 'x86_64')
 end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -1,6 +1,6 @@
 project "pdk" do |proj|
   # Inherit a bunch of shared settings from pdk-runtime config
-  proj.setting(:pdk_runtime_version, '201903260')
+  proj.setting(:pdk_runtime_version, '201906040')
   proj.inherit_settings 'pdk-runtime', 'git://github.com/puppetlabs/puppet-runtime', proj.pdk_runtime_version
 
   proj.description "Puppet Development Kit"


### PR DESCRIPTION
This should be all that's needed in pdk-vanagon once the new versions of pdk-runtime are built (https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/job/platform_pdk-runtime_runtime-vanagon-packaging_master/85/)