### PR TITLE
(PDK-1373) Remove extracted files on MSI uninstall

### DIFF
--- a/configs/components/pdk-create-ruby-tarballs.rb
+++ b/configs/components/pdk-create-ruby-tarballs.rb
@@ -5,11 +5,13 @@ component "pdk-create-ruby-tarballs" do |pkg, settings, platform|
   # We only create the tarballs on Windows right now
   if platform.is_windows?
     pkg.add_source("file://resources/files/install-tarballs/extract_all.rb")
+    pkg.add_source("file://resources/files/install-tarballs/remove_all.rb")
     pkg.directory "#{settings[:datadir]}/install-tarballs"
     # Unlike other examples, where the path would be '../<file>' we use the current workding directory.  This is because
     # even though we add a source as above, because it is not a gem or tar etc., the component has nothing to extract therefore
     # we don't end up in a component directory
     pkg.install_file "extract_all.rb", "#{settings[:datadir]}/install-tarballs/extract_all.rb"
+    pkg.install_file "remove_all.rb", "#{settings[:datadir]}/install-tarballs/remove_all.rb"
 
     pkg.build do
       build_commands = []

--- a/resources/files/install-tarballs/remove_all.rb
+++ b/resources/files/install-tarballs/remove_all.rb
@@ -1,0 +1,38 @@
+require 'pathname'
+require 'fileutils'
+
+script_dir = __dir__
+install_dir = File.expand_path(File.join(script_dir, '..', '..'))
+
+def logmessage(message)
+  puts message
+end
+
+def ruby_api_version(ruby_version)
+  gem_ver = Gem::Version.new(ruby_version)
+  gem_ver.segments[0..1].join('.') + '.0'
+end
+
+# Remove the ruby and puppet cache, but not the actual runtime for the ruby we're _actually_ using
+# right now. We need that!
+ruby_ver = RUBY_VERSION
+logmessage("Ruby version is #{ruby_ver}")
+ruby_api = ruby_api_version(ruby_ver)
+dirs_to_delete = ["private/puppet/ruby/#{ruby_api}", "share/cache/ruby/#{ruby_api}"]
+
+# Enumerate all of the ruby runtimes
+Dir.glob(File.join(install_dir, 'private', 'ruby', '*/')) do |ruby_runtime|
+  path = Pathname.new(ruby_runtime)
+  ruby_ver = path.basename.to_s
+  next if ruby_ver == RUBY_VERSION
+  ruby_api = ruby_api_version(ruby_ver)
+  # Remove the ruby and puppet cache, and the ruby runtime
+  dirs_to_delete.concat(["private/ruby/#{ruby_ver}", "private/puppet/ruby/#{ruby_api}", "share/cache/ruby/#{ruby_api}"])
+end
+
+dirs_to_delete.each { |dir| logmessage("'#{dir}' is scheduled for deletion") }
+dirs_to_delete.each do |dir|
+  absolute_dir = File.join(install_dir, dir)
+  logmessage("Attempting to delete '#{absolute_dir}'...")
+  FileUtils.rm_rf(absolute_dir)
+end

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -32,6 +32,16 @@
       Return="check"
       Impersonate="no" />
 
+    <!-- INSTALLDIR is not available for Deferred Custom Actions.  So we need to save it for later user -->
+    <CustomAction Id="SetPropertyForRemoveTarballs" Property="RemoveTarballs" Value="[INSTALLDIR]" />
+    <CustomAction
+      Id="RemoveTarballs"
+      BinaryKey="TarballScript"
+      VBScriptCall="RemoveTarballs"
+      Execute="deferred"
+      Return="check"
+      Impersonate="no" />
+
     <%- if @platform.architecture == "x86" -%>
     <!-- If these fail, we don't want to fail the installer -->
     <!-- We can't do a registry search for powershell's installed location because it will turn up the WOW64Node version due to not being able to bypass redirection in RegistrySearch

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -31,8 +31,12 @@
         <![CDATA[VersionNT64 >= 100 AND <%= settings[:win64] %> = no AND NOT (&<%= settings[:product_id] %>Runtime = 2)]]>
       </Custom>
       <%-end-%>
+      <!-- Tarball Extractor on install -->
       <Custom Action="SetPropertyForExtractTarballs" Before="InstallInitialize">NOT REMOVE</Custom>
       <Custom Action='ExtractTarballs' After='InstallFiles'>NOT REMOVE</Custom>
+      <!-- Tarball Remover on uninstall -->
+      <Custom Action="SetPropertyForRemoveTarballs" Before="InstallInitialize">REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>
+      <Custom Action='RemoveTarballs' Before='RemoveFiles'>REMOVE~="ALL" OR MaintenanceMode="Remove"</Custom>
     </InstallExecuteSequence>
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />

--- a/resources/windows/wix/tarball.vbs
+++ b/resources/windows/wix/tarball.vbs
@@ -86,7 +86,7 @@ Function GetRubyDirectory(RootDirectory)
 End Function
 
 ' Mainline
-Function ExtractTarballs()
+Function RunRubyScriptFile(ScriptFileName)
   Log "InstallDir is " + InstallDir, false
 
   ' Based on equivalent PowerShell script at;
@@ -103,7 +103,7 @@ Function ExtractTarballs()
   Dim RubyVersion : RubyVersion = GetRubyDirectory(DEVKIT_BASEDIR + "\private\ruby")
   If RubyVersion = "" Then
     Log "Could not find a suitable ruby environment", true
-    ExtractTarballs = IDABORT
+    RunRubyScriptFile = IDABORT
     Exit Function
   Else
     Log "Ruby " + RubyVersion + " has the PDK gem", false
@@ -130,19 +130,27 @@ Function ExtractTarballs()
   ProcessEnv("SSL_CERT_DIR") = SSL_CERT_DIR
   ProcessEnv("PDK_DEBUG") = "True"
 
-  Dim ExtractScript : ExtractScript = DEVKIT_BASEDIR + "\share\install-tarballs\extract_all.rb"
+  Dim ExtractScript : ExtractScript = DEVKIT_BASEDIR + "\share\install-tarballs\" + ScriptFileName
   If Not(fso.FileExists(ExtractScript)) Then
     Log "Extract script " & ExtractScript & " could not be found", true
-    ExtractTarballs = IDABORT
+    RunRubyScriptFile = IDABORT
     Exit Function
   End If
 
   ' Note Returning values back to the MSI Engine only works with Binary type Custom Actions
   if ExecuteCommand(comspec & " /C " & RubyPath & " -S -- " & ExtractScript) Then
     Log "Completed with success", false
-    ExtractTarballs = IDOK
+    RunRubyScriptFile = IDOK
   Else
     Log "Completed with error", true
-    ExtractTarballs = IDABORT
+    RunRubyScriptFile = IDABORT
   End If
+End Function
+
+Function ExtractTarballs()
+  ExtractTarballs = RunRubyScriptFile("extract_all.rb")
+End Function
+
+Function RemoveTarballs()
+  RemoveTarballs = RunRubyScriptFile("remove_all.rb")
 End Function


### PR DESCRIPTION
Previously in commit 3bbaffb06 the MSI installation process extracted the
tarballs to their correct place on disk. However because the MSI engine did not
place those files, when uninstalling the MSI Engine leaves those files behind.
This commit modifies the MSI installation process to now call a removal script.

* Updates the tarball VBScript to be able to both extract and remove the tarball
  contents
* Adds a custom action to capture the INSTALLDIR as this property is not
  available to Deferred Custom Actions
* Adds a Deferred Custom Action to remove the extracted files so that it can be
  run in an elevated context