### PR TITLE
(maint) Update byebug on Rubies > 2.1

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -88,7 +88,7 @@ component "pdk-templates" do |pkg, settings, platform|
     # Add some Beaker dependencies for Linux
     unless platform.is_windows?
       build_commands << "echo 'gem \"ruby-ll\", \"2.1.2\",                         require: false' >> #{mod_name}/Gemfile"
-      build_commands << "echo 'gem \"byebug\", \"9.0.6\",                          require: false' >> #{mod_name}/Gemfile"
+      build_commands << "echo 'gem \"byebug\", \"#{settings[:byebug_version][settings[:ruby_api]]}\", require: false' >> #{mod_name}/Gemfile"
       build_commands << "echo 'gem \"oga\", \"2.15\",                              require: false' >> #{mod_name}/Gemfile"
     end
 
@@ -149,7 +149,7 @@ component "pdk-templates" do |pkg, settings, platform|
       # Add some Beaker dependencies for Linux
       unless platform.is_windows?
         build_commands << "echo 'gem \"ruby-ll\", \"2.1.2\",                         require: false' >> #{local_mod_name}/Gemfile"
-        build_commands << "echo 'gem \"byebug\", \"9.0.6\",                          require: false' >> #{local_mod_name}/Gemfile"
+        build_commands << "echo 'gem \"byebug\", \"#{settings[:byebug_version][local_settings[:ruby_api]]}\", require: false' >> #{local_mod_name}/Gemfile"
         build_commands << "echo 'gem \"oga\", \"2.15\",                              require: false' >> #{local_mod_name}/Gemfile"
       end
 

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -47,6 +47,7 @@ project "pdk" do |proj|
   proj.setting(:bundler_version, "1.16.1")
   proj.setting(:mini_portile2_version, '2.3.0')
   proj.setting(:nokogiri_version, '1.8.5')
+  proj.setting(:byebug_version, {'2.1.0' => '9.0.6'}.tap { |h| h.default = '11.0.1' })
 
   proj.setting(:cachedir, File.join(proj.datadir, "cache"))
 


### PR DESCRIPTION
Updates byebug on Ruby > 2.1 to 11.0.1 for latest beaker.