### PR TITLE
(maint) Install byebug 9.0.6 & 11.0.1

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -88,13 +88,18 @@ component "pdk-templates" do |pkg, settings, platform|
     # Add some Beaker dependencies for Linux
     unless platform.is_windows?
       build_commands << "echo 'gem \"ruby-ll\", \"2.1.2\",                         require: false' >> #{mod_name}/Gemfile"
-      build_commands << "echo 'gem \"byebug\", \"#{settings[:byebug_version][settings[:ruby_api]]}\", require: false' >> #{mod_name}/Gemfile"
       build_commands << "echo 'gem \"oga\", \"2.15\",                              require: false' >> #{mod_name}/Gemfile"
     end
 
     # Run 'bundle install' in the generated module to cache the gems
     # inside the project cachedir.
     build_commands << "pushd #{mod_name} && #{gem_env.join(' ')} #{settings[:host_bundle]} install && popd"
+
+    unless platform.is_windows?
+      settings[:byebug_version][settings[:ruby_api]].each do |byebug_version|
+        build_commands << "#{gem_env.join(' ')} #{settings[:host_gem]} install --no-document byebug:#{byebug_version}"
+      end
+    end
 
     # Install bundler into the gem cache
     build_commands << "#{gem_env.join(' ')} #{settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler_version]}.gem"
@@ -149,12 +154,17 @@ component "pdk-templates" do |pkg, settings, platform|
       # Add some Beaker dependencies for Linux
       unless platform.is_windows?
         build_commands << "echo 'gem \"ruby-ll\", \"2.1.2\",                         require: false' >> #{local_mod_name}/Gemfile"
-        build_commands << "echo 'gem \"byebug\", \"#{settings[:byebug_version][local_settings[:ruby_api]]}\", require: false' >> #{local_mod_name}/Gemfile"
         build_commands << "echo 'gem \"oga\", \"2.15\",                              require: false' >> #{local_mod_name}/Gemfile"
       end
 
       # Install all the deps into the package cachedir.
       build_commands << "pushd #{local_mod_name} && #{local_gem_env.join(' ')} #{local_settings[:host_bundle]} install && popd"
+
+      unless platform.is_windows?
+        settings[:byebug_version][local_settings[:ruby_api]].each do |byebug_version|
+          build_commands << "#{local_gem_env.join(' ')} #{local_settings[:host_gem]} install --no-document byebug:#{byebug_version}"
+        end
+      end
 
       # Install bundler itself into the gem cache for this ruby
       build_commands << "#{local_gem_env.join(' ')} #{local_settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler_version]}.gem"

--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -118,19 +118,21 @@ component "puppet-forge-api" do |pkg, settings, platform|
       }
 
       pdk_ruby_versions.each do |rubyapi|
-        build_commands << gem_install.call(
-          rubyapi,
-          'byebug',
-          settings[:byebug_version][rubyapi],
-          '--',
-          "--with-ruby-include=#{File.join(ruby_dirs[rubyapi], 'include', "ruby-#{rubyapi}")}",
-          "--with-ruby-lib=#{File.join(ruby_dirs[rubyapi], 'lib')}",
-        )
+        settings[:byebug_version][rubyapi].each do |byebug_version|
+          build_commands << gem_install.call(
+            rubyapi,
+            'byebug',
+            byebug_version,
+            '--',
+            "--with-ruby-include=#{File.join(ruby_dirs[rubyapi], 'include', "ruby-#{rubyapi}")}",
+            "--with-ruby-lib=#{File.join(ruby_dirs[rubyapi], 'lib')}",
+          )
 
-        # Byebug 9.x requires special treatment b/c the cross compiled into a fat gem
-        if settings[:byebug_version][rubyapi].start_with?('9.')
-          byebug_libdir = File.join(puppet_cachedir, rubyapi, "gems", "byebug-#{settings[:byebug_version][rubyapi]}-x64-mingw32", "lib", "byebug")
-          build_commands << "cp #{File.join(byebug_libdir, rubyapi.split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}"
+          # Byebug 9.x requires special treatment b/c the cross compiled into a fat gem
+          if byebug_version.start_with?('9.')
+            byebug_libdir = File.join(puppet_cachedir, rubyapi, "gems", "byebug-#{byebug_version}-x64-mingw32", "lib", "byebug")
+            build_commands << "cp #{File.join(byebug_libdir, rubyapi.split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}"
+          end
         end
 
         # Add the remaining beaker dependencies that have been natively compiled

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -47,7 +47,7 @@ project "pdk" do |proj|
   proj.setting(:bundler_version, "1.16.1")
   proj.setting(:mini_portile2_version, '2.3.0')
   proj.setting(:nokogiri_version, '1.8.5')
-  proj.setting(:byebug_version, {'2.1.0' => '9.0.6'}.tap { |h| h.default = '11.0.1' })
+  proj.setting(:byebug_version, {'2.1.0' => ['9.0.6']}.tap { |h| h.default = ['9.0.6', '11.0.1'] })
 
   proj.setting(:cachedir, File.join(proj.datadir, "cache"))
 


### PR DESCRIPTION
Installs them side by side to work around the nondeterministic behaviour of Bundler.