### PR TITLE
(maint) Rake task to automate checking PDK download links

### DIFF
--- a/rakelib/check_download_links.rake
+++ b/rakelib/check_download_links.rake
@@ -1,0 +1,69 @@
+require 'net/http'
+require 'net/https'
+require 'uri'
+
+desc "Check that PDK download links point to the correct version"
+task :check_download_links, [:version] do |_task, args|
+  version = args[:version] || `git describe --abbrev=0`
+  puts "Checking that PDK download links point to #{version}"
+  DownloadLinkCheck.new.check_latest(version)
+end
+
+class DownloadLinkCheck
+  HOST='pm.puppet.com'
+
+  def check_latest(expected_version)
+    failure = false
+
+    platforms.each do |platform|
+      dist, rel, arch = platform.split('-')
+      dist = 'win' if dist == 'windows'
+      params = [
+        "dist=#{dist}",
+        "rel=#{rel}",
+        "arch=#{arch}",
+        "ver=latest",
+      ]
+
+      print "#{platform} => "
+      begin
+        download_url = request("https://#{HOST}/cgi-bin/pdk_download.cgi?#{params.join('&')}")
+        if download_url.include?(expected_version)
+          puts "OK"
+        else
+          puts "Incorrect version! #{download_url}"
+          failure = true
+        end
+      rescue ArgumentError => e
+        failure = true
+        puts e.message
+      end
+    end
+
+    abort if failure
+  end
+
+  def platforms
+    platform_dir = File.expand_path(File.join(__dir__, '..', 'configs', 'platforms'))
+    Dir.glob(File.join(platform_dir, '*.rb')).map { |r| File.basename(r, '.rb') }.sort
+  end
+
+  def request(url, limit=5)
+    raise ArgumentError, 'HTTP request too deep' if limit.zero?
+
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    response = http.head(uri.request_uri)
+
+    case response
+    when Net::HTTPSuccess
+      url
+    when Net::HTTPRedirection
+      request(response['location'], limit - 1)
+    else
+      raise ArgumentError, "#{response.code} (#{response.message}): #{url}"
+    end
+  end
+end


### PR DESCRIPTION
Fetches the list of platforms from the vanagon config (which is the
cause of the 2 Fedora related failures seen in the examples below, we no
longer build for those Fedora versions but they remain in our config).
The task then hits the pdk_download.cgi script and follows the redirects
until it gets to the actual package. If any of the package URLs do not
contain the specified version, the task will exit non-zero.

By default, the task will use the latest annotated tag name as the
version.
```
$ bundle exec rake check_download_links
Checking that PDK download links point to 1.11.1.0
debian-8-amd64 => Incorrect version! https://apt.puppet.com/pool/jessie/puppet/p/pdk/pdk_1.11.0.0-1jessie_amd64.deb
debian-9-amd64 => Incorrect version! https://apt.puppet.com/pool/stretch/puppet/p/pdk/pdk_1.11.0.0-1stretch_amd64.deb
el-6-x86_64 => Incorrect version! https://yum.puppet.com/puppet/el/6/x86_64/pdk-1.11.0.0-1.el6.x86_64.rpm
el-7-x86_64 => Incorrect version! https://yum.puppet.com/puppet/el/7/x86_64/pdk-1.11.0.0-1.el7.x86_64.rpm
fedora-26-x86_64 => 404 (Not Found): https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=fedora&rel=26&arch=x86_64&ver=latest
fedora-27-x86_64 => 404 (Not Found): https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=fedora&rel=27&arch=x86_64&ver=latest
fedora-28-x86_64 => Incorrect version! https://yum.puppet.com/puppet/fedora/28/x86_64/pdk-1.11.0.0-1.fc28.x86_64.rpm
fedora-29-x86_64 => Incorrect version! https://yum.puppet.com/puppet/fedora/29/x86_64/pdk-1.11.0.0-1.fc29.x86_64.rpm
osx-10.11-x86_64 => Incorrect version! https://downloads.puppet.com/mac/puppet/10.11/x86_64/pdk-1.11.0.0-1.osx10.11.dmg
osx-10.12-x86_64 => Incorrect version! https://downloads.puppet.com/mac/puppet/10.12/x86_64/pdk-1.11.0.0-1.osx10.12.dmg
osx-10.13-x86_64 => Incorrect version! https://downloads.puppet.com/mac/puppet/10.13/x86_64/pdk-1.11.0.0-1.osx10.13.dmg
osx-10.14-x86_64 => Incorrect version! https://downloads.puppet.com/mac/puppet/10.14/x86_64/pdk-1.11.0.0-1.osx10.14.dmg
sles-11-x86_64 => Incorrect version! https://yum.puppet.com/puppet/sles/11/x86_64/pdk-1.11.0.0-1.sles11.x86_64.rpm
sles-12-x86_64 => Incorrect version! https://yum.puppet.com/puppet/sles/12/x86_64/pdk-1.11.0.0-1.sles12.x86_64.rpm
ubuntu-14.04-amd64 => Incorrect version! https://apt.puppet.com/pool/trusty/puppet/p/pdk/pdk_1.11.0.0-1trusty_amd64.deb
ubuntu-16.04-amd64 => Incorrect version! https://apt.puppet.com/pool/xenial/puppet/p/pdk/pdk_1.11.0.0-1xenial_amd64.deb
ubuntu-18.04-amd64 => Incorrect version! https://apt.puppet.com/pool/bionic/puppet/p/pdk/pdk_1.11.0.0-1bionic_amd64.deb
windows-2012r2-x64 => Incorrect version! https://downloads.puppet.com/windows/puppet/pdk-1.11.0.0-x64.msi
```

But, you can also specify a version.
```
$ bundle exec rake check_download_links[1.11.0.0]
Checking that PDK download links point to 1.11.0.0
debian-8-amd64 => OK
debian-9-amd64 => OK
el-6-x86_64 => OK
el-7-x86_64 => OK
fedora-26-x86_64 => 404 (Not Found): https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=fedora&rel=26&arch=x86_64&ver=latest
fedora-27-x86_64 => 404 (Not Found): https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=fedora&rel=27&arch=x86_64&ver=latest
fedora-28-x86_64 => OK
fedora-29-x86_64 => OK
osx-10.11-x86_64 => OK
osx-10.12-x86_64 => OK
osx-10.13-x86_64 => OK
osx-10.14-x86_64 => OK
sles-11-x86_64 => OK
sles-12-x86_64 => OK
ubuntu-14.04-amd64 => OK
ubuntu-16.04-amd64 => OK
ubuntu-18.04-amd64 => OK
windows-2012r2-x64 => OK
```

Eventually, this task could be added to our pipeline to run after the
ship job and we could remove one of the manual tasks in the shipping
ceremony.