### PR TITLE
(maint) Install rb-readline into all ruby runtimes on Windows

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -142,6 +142,8 @@ component "puppet-forge-api" do |pkg, settings, platform|
         build_commands += beaker_native_deps.collect do |gem, ver|
           gem_install.call(rubyapi, gem, ver)
         end
+
+        build_commands << gem_install.call(rubyapi, 'rb-readline', '0.5.5')
       end
     end
 


### PR DESCRIPTION
https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-van-build_adhoc/BUILD_TARGET=windows-2012r2-x64,SLAVE_LABEL=beaker/52/