### PR TITLE
(FIXUP) Make chmod only output changes on all platforms

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -187,7 +187,8 @@ component "pdk-templates" do |pkg, settings, platform|
     end
 
     # Fix permissions
-    build_commands << "chmod -R -vv ugo+r #{File.join(settings[:cachedir], 'ruby')} #{File.join(settings[:privatedir], 'puppet', 'ruby')}"
+    chmod_changes_flag = platform.is_macos? ? "-vv" : "--changes"
+    build_commands << "chmod -R #{chmod_changes_flag} ugo+r #{File.join(settings[:cachedir], 'ruby')} #{File.join(settings[:privatedir], 'puppet', 'ruby')}"
 
     pre_build_commands + build_commands
   end


### PR DESCRIPTION
This will make it so the `chmod` invocation only prints changed modes on all platforms (currently it prints every file inspected on Linux which adds a lot of bloat to the build logs)

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-van-build_adhoc/53/