### PR TITLE
(maint) Be specific about Puppet major version for nonfinal_repo_name

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -22,7 +22,13 @@ osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
 repo_name: 'puppet-enterprise-tools'
-nonfinal_repo_name: 'puppet-nightly'
+
+# (eric.griswold) There is an unfortunate symlink vs. directory
+# condition that arises when we use 'puppet-nightly' for
+# nonfinal_repo_name and add a new platform. Until we solve that, this
+# will need to get updated every time we have a new puppet major
+# release.
+nonfinal_repo_name: 'puppet6-nightly'
 build_tar: FALSE
 staging_server: 'weth.delivery.puppetlabs.net'
 msi_staging_server: 'weth.delivery.puppetlabs.com'


### PR DESCRIPTION
Ugh. There's a set of circumstances where if PDK releases a new nightly
into 'puppet-nightly', it can create a directory in the place of a desired
symlink, causing puppet-agent problems later.

For now, be very specify about which repo nightly (aka nonfinal) builds
are delivered to.