### PR TITLE
(maint) Enforce latest rspec-puppet version

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -79,6 +79,8 @@ component "pdk-templates" do |pkg, settings, platform|
     # Run 'bundle lock' in the generated module and cache the Gemfile.lock
     # inside the project cachedir. We add the private/puppet paths to
     # GEM_PATH to make sure we resolve to a cached version of puppet.
+    build_commands << "echo 'gem \"rspec-puppet\", \"#{settings[:rspec_puppet_version]}\", require: false' >> #{mod_name}/Gemfile"
+
     build_commands << "pushd #{mod_name} && #{gem_env.join(' ')} #{settings[:host_bundle]} lock && popd"
 
     # Copy generated Gemfile.lock into cachedir.
@@ -142,6 +144,8 @@ component "pdk-templates" do |pkg, settings, platform|
 
       # Generate a new module for this ruby version.
       build_commands << "#{pdk_bin} new module #{local_mod_name} --skip-interview --template-url=file:///#{File.join(settings[:cachedir], 'pdk-templates.git')}"
+
+      build_commands << "echo 'gem \"rspec-puppet\", \"#{settings[:rspec_puppet_version]}\", require: false' >> #{local_mod_name}/Gemfile"
 
       # Resolve default gemfile deps
       build_commands << "pushd #{local_mod_name} && #{local_gem_env.join(' ')} #{local_settings[:host_bundle]} update && popd"

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -44,6 +44,7 @@ project "pdk" do |proj|
   # TODO: Migrate more components to use this
   proj.setting(:rubygems_url, "#{proj.artifactory_url}/rubygems/gems")
 
+  proj.setting(:rspec_puppet_version, Gem.latest_version_for('rspec-puppet').to_s)
   proj.setting(:bundler_version, "1.16.1")
   proj.setting(:byebug_version, {'2.1.0' => ['9.0.6']}.tap { |h| h.default = ['9.0.6', '11.0.1'] })
 


### PR DESCRIPTION
Force bundler to use the latest rspec-puppet release when resolving the lockfiles.

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-int-sys-testing_adhoc/58/