### PR TITLE
(maint) Pin packaging gem to 0.99.45

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.19')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.4')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '0.99.45')
 gem 'rake', '~> 12.0'
 
 #gem 'rubocop', "~> 0.34.2"


### PR DESCRIPTION
The latest version of the packaging gem pulls in a new dependency (csv) that is
incompatible with Ruby 2.2.5 which is used in the generic vanagon-promote job.