### PR TITLE
(PDK-1504,PDK-1524) Populate Ruby version in files during build

### DIFF
--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -15,6 +15,21 @@ component "rubygem-pdk" do |pkg, settings, platform|
     ]
   end
 
+  # Replace the @@@RUBY_VERSION@@@ placeholder in the wrapper script or
+  # powershell module with the Ruby version specified in the pdk-runtime
+  # settings.
+  pkg.build do
+    wrapper = if platform.is_windows?
+                File.join('..', 'PuppetDevelopmentKit.psm1')
+              else
+                File.join('..', 'pdk_env_wrapper')
+              end
+
+    [
+      "sed -i -e 's/@@@RUBY_VERSION@@@/#{settings[:ruby_version]}/' #{wrapper}",
+    ]
+  end
+
   if platform.is_windows?
     # PowerShell Module
     pkg.add_source("file://resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1", sum: "ec3c0df4948b9c7c11ff665546e2e0ec")

--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -15,9 +15,6 @@ component "rubygem-pdk" do |pkg, settings, platform|
     ]
   end
 
-  # Replace the @@@RUBY_VERSION@@@ placeholder in the wrapper script or
-  # powershell module with the Ruby version specified in the pdk-runtime
-  # settings.
   pkg.build do
     wrapper = if platform.is_windows?
                 File.join('..', 'PuppetDevelopmentKit.psm1')
@@ -25,14 +22,22 @@ component "rubygem-pdk" do |pkg, settings, platform|
                 File.join('..', 'pdk_env_wrapper')
               end
 
+    # Replace the @@@RUBY_VERSION@@@ placeholder in the wrapper script or
+    # powershell module with the Ruby version specified in the pdk-runtime
+    # settings.
     build_commands = [
       "sed -i -e 's/@@@RUBY_VERSION@@@/#{settings[:ruby_version]}/' #{wrapper}",
     ]
 
-    if platform.windows?
+    if platform.is_windows?
       psd_file = File.join('..', 'PuppetDevelopmentKit.psd1')
 
-      build_commands << "sed -i -e 's/@@@YEAR@@@/#{Time.now.utc.year}/' #{psd_file}"
+      # Replace the @@@YEAR@@@ and @@@PDK_VERSION@@@ placeholders in the PSData
+      # with the current year and PDK version.
+      build_commands += [
+        "sed -i -e 's/@@@YEAR@@@/#{Time.now.utc.year}/' #{psd_file}",
+        "sed -i -e 's/@@@PDK_VERSION@@@/#{Gem::Version.new(pkg.get_version).release}/' #{psd_file}",
+      ]
     end
 
     build_commands

--- a/configs/components/rubygem-pdk.rb
+++ b/configs/components/rubygem-pdk.rb
@@ -25,9 +25,17 @@ component "rubygem-pdk" do |pkg, settings, platform|
                 File.join('..', 'pdk_env_wrapper')
               end
 
-    [
+    build_commands = [
       "sed -i -e 's/@@@RUBY_VERSION@@@/#{settings[:ruby_version]}/' #{wrapper}",
     ]
+
+    if platform.windows?
+      psd_file = File.join('..', 'PuppetDevelopmentKit.psd1')
+
+      build_commands << "sed -i -e 's/@@@YEAR@@@/#{Time.now.utc.year}/' #{psd_file}"
+    end
+
+    build_commands
   end
 
   if platform.is_windows?

--- a/resources/files/posix/pdk_env_wrapper
+++ b/resources/files/posix/pdk_env_wrapper
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # avoid influences from already pre-configured other ruby environments
-env -u GEM_HOME -u GEM_PATH -u DLN_LIBRARY_PATH -u RUBYLIB -u RUBYLIB_PREFIX -u RUBYOPT -u RUBYPATH -u RUBYSHELL -u LD_LIBRARY_PATH -u LD_PRELOAD SHELL=/bin/sh /opt/puppetlabs/pdk/private/ruby/2.4.9/bin/pdk "$@"
+env -u GEM_HOME -u GEM_PATH -u DLN_LIBRARY_PATH -u RUBYLIB -u RUBYLIB_PREFIX -u RUBYOPT -u RUBYPATH -u RUBYSHELL -u LD_LIBRARY_PATH -u LD_PRELOAD SHELL=/bin/sh /opt/puppetlabs/pdk/private/ruby/@@@RUBY_VERSION@@@/bin/pdk "$@"

--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
@@ -1,6 +1,6 @@
 @{
   ModuleToProcess   = 'PuppetDevelopmentKit.psm1'
-  ModuleVersion     = '1.14.0'
+  ModuleVersion     = '@@@PDK_VERSION@@@'
   GUID              = 'bfe70e90-1802-4f6b-b4a0-f627d53f593f'
   Author            = "Puppet, Inc"
   CompanyName       = "Puppet, Inc"

--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1
@@ -4,7 +4,7 @@
   GUID              = 'bfe70e90-1802-4f6b-b4a0-f627d53f593f'
   Author            = "Puppet, Inc"
   CompanyName       = "Puppet, Inc"
-  Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
+  Copyright         = '(c) @@@YEAR@@@ Puppet, Inc. All rights reserved'
   FunctionsToExport = @('pdk')
   CmdletsToExport   = @()
   VariablesToExport = @()

--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -3,7 +3,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 $env:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
 $env:DEVKIT_BASEDIR = $fso.GetFolder($env:DEVKIT_BASEDIR).ShortPath
-$env:RUBY_DIR       = "$($env:DEVKIT_BASEDIR)\private\ruby\2.4.9"
+$env:RUBY_DIR       = "$($env:DEVKIT_BASEDIR)\private\ruby\@@@RUBY_VERSION@@@"
 $env:SSL_CERT_FILE  = "$($env:DEVKIT_BASEDIR)\ssl\cert.pem"
 $env:SSL_CERT_DIR   = "$($env:DEVKIT_BASEDIR)\ssl\certs"
 


### PR DESCRIPTION
Rather than hardcode the Ruby version in the wrapper script and
PowerShell module, this will populate that value during build time from
the pdk-runtime vanagon config.

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-int-sys-testing_adhoc/62/