### PR TITLE
(PDK-1546) Add Fedora 31 to platform configs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.19')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '0.99.45')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '0.99.49')
 gem 'rake', '~> 12.0'
 
 #gem 'rubocop', "~> 0.34.2"

--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -12,20 +12,22 @@ component "pdk-templates" do |pkg, settings, platform|
   pkg.build_requires "rubygem-pdk"
   pkg.build_requires "puppet-forge-api"
 
-  platforms_without_plgcc = %w[
-    debian-10-amd64
-    fedora-26-x86_64
-    fedora-27-x86_64
-    fedora-28-x86_64
-    fedora-29-x86_64
-    fedora-30-x86_64
-    ubuntu-18.04-amd64
-    el-8-x86_64
-  ]
+  def use_plgcc?(platform)
+    platforms_without_plgcc = %w[
+      debian-10-amd64
+      ubuntu-18.04-amd64
+      el-8-x86_64
+    ]
+
+    return false if platforms_without_plgcc.include?(platform.name)
+    return false if platform.is_fedora? && platform.os_version.to_i >= 26
+
+    true
+  end
 
   if platform.is_windows?
     pkg.environment "PATH", settings[:gem_path_env]
-  elsif platform.is_linux? && !platforms_without_plgcc.include?(platform.name)
+  elsif platform.is_linux? && use_plgcc?(platform)
     pkg.build_requires "pl-gcc"
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   end

--- a/configs/platforms/fedora-31-x86_64.rb
+++ b/configs/platforms/fedora-31-x86_64.rb
@@ -1,0 +1,17 @@
+platform "fedora-31-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.vmpooler_template "fedora-31-x86_64"
+  plat.dist "fc31"
+
+  packages = %w[
+    autoconf automake bzip2-devel gcc gcc-c++
+    make cmake pkgconfig readline-devel
+    rpm-libs rpmdevtools rsync swig zlib-devel
+  ]
+  plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
+
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+end


### PR DESCRIPTION
Depends on https://github.com/puppetlabs/puppet-runtime/pull/248 (can drop e20d579 and bump runtime version once merged)

Successful build: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-int-sys-testing_adhoc/72/