### PR TITLE
(PDK-1548) Add a dummy location value to puppet-runtime.json

### DIFF
--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"version": "201910020"}
+{"version": "201910020", "location": "http://builds.delivery.puppetlabs.net/puppet-runtime/201910020/artifacts/"}


### PR DESCRIPTION
We don't actually use this value, but it needs to be in place for the vanagon-component-promote script's validation logic.