### PR TITLE
(maint) Fetch task schema from puppetlabs/puppet-specifications

### DIFF
--- a/configs/components/puppet-forge-api.rb
+++ b/configs/components/puppet-forge-api.rb
@@ -155,7 +155,4 @@ component "puppet-forge-api" do |pkg, settings, platform|
 
   # Cache the PE to puppet version mapping.
   pkg.install_file('lib/pe_versions.json', File.join(settings[:cachedir], 'pe_versions.json'))
-
-  # Cache the task metadata schema.
-  pkg.install_file('app/static/schemas/task.json', File.join(settings[:cachedir], 'task.json'))
 end

--- a/configs/components/puppet-specifications.rb
+++ b/configs/components/puppet-specifications.rb
@@ -1,0 +1,9 @@
+component "puppet-specifications" do |pkg, settings, platform|
+  pkg.ref "master"
+  pkg.url "git@github.com:puppetlabs/puppet-specifications.git"
+
+  pkg.build_requires "pdk-runtime"
+
+  # Cache the task metadata schema.
+  pkg.install_file(File.join('tasks', 'task.json'), File.join(settings[:cachedir], 'task.json'))
+end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -166,6 +166,7 @@ project "pdk" do |proj|
   proj.component "pdk-templates"
 
   # Cache puppet gems, task metadata schema, etc.
+  proj.component "puppet-specifications"
   proj.component "puppet-forge-api"
 
   proj.component "gem-prune"


### PR DESCRIPTION
As of puppetlabs/puppet-forge-api#578, the task schema is no longer in
the puppet-forge-api repo.

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-int-sys-testing_adhoc/71/