### PR TITLE
(PDK-1547) Set SSL Env vars before running PDK in PowerShell Module

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -1,11 +1,9 @@
 $fso = New-Object -ComObject Scripting.FileSystemObject
 
-$env:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
+$script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
-$env:DEVKIT_BASEDIR = $fso.GetFolder($env:DEVKIT_BASEDIR).ShortPath
-$env:RUBY_DIR       = "$($env:DEVKIT_BASEDIR)\private\ruby\@@@RUBY_VERSION@@@"
-$env:SSL_CERT_FILE  = "$($env:DEVKIT_BASEDIR)\ssl\cert.pem"
-$env:SSL_CERT_DIR   = "$($env:DEVKIT_BASEDIR)\ssl\certs"
+$script:DEVKIT_BASEDIR = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
+$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.4.9"
 
 function pdk {
   if ($Host.Name -eq 'Windows PowerShell ISE Host') {
@@ -15,13 +13,16 @@ function pdk {
     return
   }
 
+  # Reset The SSL Environment Variables
+  $env:SSL_CERT_FILE  = "$($script:DEVKIT_BASEDIR)\ssl\cert.pem"
+  $env:SSL_CERT_DIR   = "$($script:DEVKIT_BASEDIR)\ssl\certs"
   # Don't use Ansicon under Conemu or Windows Terminal
   # - ConEmuANSI is set to ON for Conemu
   # - WT_SESSION is set when using Windows Terminal
   if (($env:ConEmuANSI -eq 'ON') -or ($null -ne $ENV:WT_SESSION)) {
-    &$env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\pdk $args
+    &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\pdk $args
   } else {
-    &$env:DEVKIT_BASEDIR\private\tools\bin\ansicon.exe $env:RUBY_DIR\bin\ruby -S -- $env:RUBY_DIR\bin\pdk $args
+    &$script:DEVKIT_BASEDIR\private\tools\bin\ansicon.exe $script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\pdk $args
   }
 }
 


### PR DESCRIPTION
Previously the the PDK PowerShell module was susceptible to external environment
variable changes once the module was loaded.  For example run PDK, then Bolt and
then PDK again, it then fails with a Ruby error.  This was due to the module
setting Environment Variables only once during the module loading process.

This commit:
* Changes some of the variables to be module scoped ($Script) instead of
  environment, as it's not needed.
* Modifies the SSL based env. vars prior to invoking PDK every time, instead of
  only once.