### PR TITLE
(MAINT) Add `--skip-bundle-install` to additional rubies

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -143,7 +143,7 @@ component "pdk-templates" do |pkg, settings, platform|
       local_mod_name = "vanagon_module_#{local_settings[:ruby_version].gsub(/[^0-9]/, '')}"
 
       # Generate a new module for this ruby version.
-      build_commands << "#{pdk_bin} new module #{local_mod_name} --skip-interview --template-url=file:///#{File.join(settings[:cachedir], 'pdk-templates.git')}"
+      build_commands << "#{pdk_bin} new module #{local_mod_name} --skip-interview --template-url=file:///#{File.join(settings[:cachedir], 'pdk-templates.git')} --skip-bundle-install"
 
       # Resolve default gemfile deps
       build_commands << "pushd #{local_mod_name} && #{local_gem_env.join(' ')} #{local_settings[:host_bundle]} update && popd"


### PR DESCRIPTION
Not sure why this wasn't added at the same time we added it for primary rubies, but it seems to be causing problems for the additional rubies now, probably related to the Rubygems/Bundler release.