### PR TITLE
(MAINT) Bump Ruby version in PowerShell wrapper script

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -3,7 +3,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 $script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
 $script:DEVKIT_BASEDIR = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
-$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.4.9"
+$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.4.10"
 
 function pdk {
   if ($Host.Name -eq 'Windows PowerShell ISE Host') {


### PR DESCRIPTION
@jpogran Is there a quick way we could just have this script resolve the path dynamically? There should only ever be one 2.4.x version in that directory.