### PR TITLE
(MAINT) Re-enable bundle pre-install for Puppet 7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.16.1')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '0.99.66')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.17.0')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '0.99.74')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
 gem 'csv', '3.1.5' if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.5.0')

--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -114,10 +114,6 @@ component "pdk-templates" do |pkg, settings, platform|
 
     # Bundle install for each additional ruby version as well, in case we need different versions for a different ruby.
     settings[:additional_rubies]&.each do |rubyver, local_settings|
-      # FIXME: Don't bundle install on Ruby 2.7 for now, waiting on either dropping litmus dependency in
-      # puppet-module-gems for 2.7 or a Bolt gem release that supports Puppet 7.x
-      next if rubyver =~ /^2\.7/
-
       local_ruby_cachedir = File.join(settings[:cachedir], 'ruby', local_settings[:ruby_api])
 
       local_gem_path = [


### PR DESCRIPTION
Note that we still won't have the beaker deps pre-installed due to
issues with native extensions in beaker deps on Windows.