### PR TITLE
Only install system_tests gem on the main ruby

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -124,6 +124,7 @@ component "pdk-templates" do |pkg, settings, platform|
       local_gem_env = [
         "GEM_PATH=\"#{local_gem_path}\"",
         "GEM_HOME=\"#{local_ruby_cachedir}\"",
+        "BUNDLE_WITHOUT=\"system_tests\"",
       ]
 
       local_nokogiri_version = settings[:nokogiri_version][local_settings[:ruby_api]][:version]


### PR DESCRIPTION
This is the second part for https://github.com/puppetlabs/pdk/pull/935 making sure litmus is still installed with the pdk, but is not burdening down the alternative rubies.

This is not tested, as I currently have no VPN access. I hope I managed to find the right spot.