### PR TITLE
(RE-13454) Remove old gpg key from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -12,7 +12,6 @@ foss_platforms:
   - ubuntu-16.04-amd64
   - windows-2012-x64
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '7F438280EF8D349F'
 deb_targets: 'trusty-amd64 xenial-amd64'
 rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE


### PR DESCRIPTION
The `gpg_key` setting is overridden by the one in `build-data`. Remove the
local soon-to-be-expired GPG key from the local repo for clarity and
cleanliness.