### PR TITLE
(MAINT) Refactor `puppet-forge-api` component into `puppet-versions`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'csv', '3.1.5' if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.5
 
 gem 'rake', '~> 12.0'
 
+gem 'gems' # Rubygems API
+
 #gem 'rubocop', "~> 0.34.2"
 group :ci do
   # in the ci pipeline, we calculate required ressources for TEST_TARGETS with bhg

--- a/configs/components/gem-prune.rb
+++ b/configs/components/gem-prune.rb
@@ -1,7 +1,7 @@
 component 'gem-prune' do |pkg, settings, platform|
   pkg.build_requires 'pdk-runtime'
   pkg.build_requires 'pdk-templates'
-  pkg.build_requires 'puppet-forge-api'
+  pkg.build_requires 'puppet-versions'
 
   pkg.add_source('file://resources/rubygems-prune')
 

--- a/configs/components/gem-prune.rb
+++ b/configs/components/gem-prune.rb
@@ -17,7 +17,7 @@ component 'gem-prune' do |pkg, settings, platform|
       gem_bins[local_settings[:ruby_api]] = local_settings[:host_gem]
     end
 
-    pdk_ruby_versions = ['2.4.0', '2.5.0']
+    pdk_ruby_versions = ['2.4.0', '2.5.0', '2.7.0']
 
     pdk_ruby_versions.map do |rubyapi|
       gem_paths = [

--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -8,7 +8,7 @@ component "pdk-templates" do |pkg, settings, platform|
   pkg.build_requires "rubygem-mini_portile2"
   pkg.build_requires "rubygem-nokogiri"
   pkg.build_requires "rubygem-pdk"
-  pkg.build_requires "puppet-forge-api"
+  pkg.build_requires "puppet-versions"
 
   pkg.add_source("file://resources/patches/bundler-relative-rubyopt.patch")
 

--- a/configs/components/rubygem-bundler.rb
+++ b/configs/components/rubygem-bundler.rb
@@ -1,7 +1,7 @@
 component "rubygem-bundler" do |pkg, settings, platform|
   pkg.version settings[:bundler_version]
   pkg.md5sum "050e5b444129ba2516d9756657755c61"
-  pkg.url "#{settings[:rubygems_url]}/bundler-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:artifactory_url]}/rubygems/gems/bundler-#{pkg.get_version}.gem"
 
   pkg.build_requires "pdk-runtime"
 

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -49,7 +49,7 @@ project "pdk" do |proj|
 
   # Internal rubygems mirror
   # TODO: Migrate more components to use this
-  proj.setting(:rubygems_url, "#{proj.artifactory_url}/rubygems/gems")
+  proj.setting(:rubygems_url, "#{proj.artifactory_url}/api/gems/rubygems")
 
   proj.setting(:bundler_version, "2.1.4")
   proj.setting(:byebug_version, {
@@ -181,12 +181,12 @@ project "pdk" do |proj|
   # PDK
   proj.component "rubygem-pdk"
 
-  # Batteries included copies of module template and required gems
-  proj.component "pdk-templates"
-
   # Cache puppet gems, task metadata schema, etc.
   proj.component "puppet-specifications"
-  proj.component "puppet-forge-api"
+  proj.component "puppet-versions"
+
+  # Batteries included copies of module template and required gems
+  proj.component "pdk-templates"
 
   proj.component "gem-prune"
 

--- a/resources/puppet-versions/README
+++ b/resources/puppet-versions/README
@@ -1,0 +1,3 @@
+This directory needs to be here so vanagon has something to copy for the `puppet-versions`
+component. However that component has no source code so this directory is functionally
+empty.


### PR DESCRIPTION
The `puppet-forge-api` component originally pulled in multiple files
from the Forge API codebase (which is a private repo) but at this point
it was only pulling in the PE version mapping file which is now
available from a public API endpoint that we can just pull from at build
time.

This PR refactors the component into a "file" based component that
queries the Rubygems API to gather a list of Puppet gem versions and
installs them into the appropriate gem caches.