### PR TITLE
(maint) Disable ansicon in VS Code

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -23,6 +23,8 @@ function pdk {
     ($env:ConEmuANSI -eq 'ON') -or
     # WT_SESSION is set when using Windows Terminal
     ($null -ne $ENV:WT_SESSION) -or
+    # TERM_PROGRAM is set when using VS Code intergrated terminal
+    ($null -ne $ENV:TERM_PROGRAM) -or
     # Host.Name is set to ServerRemoteHost for a remote PowerShell session.
     ($Host.Name -eq 'ServerRemoteHost')
   )


### PR DESCRIPTION
This disables ansicon on Windows when running PDK in the intergrated terminal in VS Code. This prevents terminal wrapping issues and loss of terminal history due to ansicon attempting to control a modern conhost.

Fixes: https://github.com/puppetlabs/pdk/issues/829