### PR TITLE
(MAINT) Update RHEL platform configs to use RedHat pooler images

### DIFF
--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -4,7 +4,7 @@ platform "el-6-x86_64" do |plat|
   plat.servicetype "sysv"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/x86_64/pl-build-tools-release-6-1.noarch.rpm"
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc gcc-c++ make rpmdevtools rpm-libs yum-utils"
+  plat.provision_with "yum install --assumeyes --nogpgcheck autoconf automake createrepo rsync gcc gcc-c++ make rpmdevtools rpm-libs yum-utils"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-6-x86_64"
+  plat.vmpooler_template "redhat-6-x86_64"
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -5,7 +5,7 @@ platform "el-7-x86_64" do |plat|
 
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc gcc-c++ make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.provision_with "yum install --assumeyes --nogpgcheck autoconf automake createrepo rsync gcc gcc-c++ make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-7-x86_64"
+  plat.vmpooler_template "redhat-7-x86_64"
 end


### PR DESCRIPTION
The CentOS mirrors for RHEL/Centos 6 have gone away and the mirrors for
7 will likely go away suddenly in the future as well. This change
switches the platform configs to use the actual RHEL images from
vmpooler instead of the Centos images we were using before.