### PR TITLE
(puppetlabs/pdk#1093) Add new platform support for pdk; Bump vanagon ver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21')
+gem 'vanagon', git: 'https://github.com/puppetlabs/vanagon', ref: 'main'
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.99.76')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
@@ -25,3 +25,5 @@ group :ci do
   # in the ci pipeline, we calculate required ressources for TEST_TARGETS with bhg
   gem 'beaker-hostgenerator', '~> 1.2'
 end
+
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', git: 'https://github.com/puppetlabs/vanagon', ref: 'main'
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21.2')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.99.76')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
@@ -25,5 +25,3 @@ group :ci do
   # in the ci pipeline, we calculate required ressources for TEST_TARGETS with bhg
   gem 'beaker-hostgenerator', '~> 1.2'
 end
-
-gem 'pry'

--- a/configs/platforms/debian-11-amd64.rb
+++ b/configs/platforms/debian-11-amd64.rb
@@ -1,0 +1,3 @@
+platform "debian-11-amd64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/fedora-32-x86_64.rb
+++ b/configs/platforms/fedora-32-x86_64.rb
@@ -1,0 +1,3 @@
+platform "fedora-32-x86_64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/fedora-34-x86_64.rb
+++ b/configs/platforms/fedora-34-x86_64.rb
@@ -1,0 +1,3 @@
+platform "fedora-34-x86_64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -1,0 +1,3 @@
+platform "osx-11-x86_64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/windows-2019-x64.rb
+++ b/configs/platforms/windows-2019-x64.rb
@@ -1,5 +1,5 @@
-platform "windows-2012r2-x64" do |plat|
-  plat.vmpooler_template "win-2012r2-x86_64"
+platform "windows-2019-x64" do |plat|
+  plat.vmpooler_template "win-2019-x86_64"
 
   plat.servicetype "windows"
   visual_studio_version = '2017'


### PR DESCRIPTION
Adds the following new build and test targets for the PDK build
pipelines:

- Debian 11
- Fedora 32
- Fedora 34
- OSX 11

Bumps the Windows build and test targets from 2012 R2 -> 2019.

Bumps vanagon to `~> 0.21.2` - this is the minimum version required
to obtain support for Debian 11.

------

**This PR is blocked from merging until:**
- [ ] Vanagon `0.21.2` is [released](https://tickets.puppetlabs.com/browse/RE-14162)
- [ ] https://github.com/puppetlabs/ci-job-configs/pull/7903 is merged