### PR TITLE
(puppetlabs/pdk#1126) Removal of Ruby 2.4. Default now 2.5

### DIFF
--- a/configs/components/rubygem-json_pure.rb
+++ b/configs/components/rubygem-json_pure.rb
@@ -11,7 +11,6 @@ component "rubygem-json_pure" do |pkg, settings, platform|
   pkg.install do
     [
       "#{settings[:gem_install]} json_pure-#{pkg.get_version}.gem",
-      "#{settings[:additional_rubies]['2.5.9'][:gem_install]} json_pure-#{pkg.get_version}.gem"
     ]
   end
 end

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -10,7 +10,6 @@ project "pdk" do |proj|
   proj.license "See components"
   proj.vendor "Puppet, Inc. <info@puppet.com>"
   proj.homepage "https://www.puppet.com"
-  proj.target_repo "puppet5"
 
   platform = proj.get_platform
 

--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -3,7 +3,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 $script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
 $script:DEVKIT_BASEDIR = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
-$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.4.10"
+$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.5.9"
 
 function pdk {
   if ($Host.Name -eq 'Windows PowerShell ISE Host') {

--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -2,7 +2,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 
 $script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
-$script:DEVKIT_BASEDIR = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
+$script:DEVKIT_BASEDIR_SHORT = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
 $script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.5.9"
 
 function pdk {
@@ -32,7 +32,7 @@ function pdk {
   if ($skip_ansicon) {
     &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\pdk $args
   } else {
-    &$script:DEVKIT_BASEDIR\private\tools\bin\ansicon.exe $script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\pdk $args
+    &$script:DEVKIT_BASEDIR_SHORT\private\tools\bin\ansicon.exe $script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\pdk $args
   }
 }
 


### PR DESCRIPTION
This PR requires: 

- https://github.com/puppetlabs/puppet-runtime/pull/478
- https://github.com/puppetlabs/pdk/pull/1130

Once these have been reviewed and merged the auto-promotion from those repos into pdk-vanagon will all this PR to remove the 2 commits tagged REMOVE

These PRs support the runtime and platform changes.