### PR TITLE
(maint) Remove platform definitions for EOL platforms

### DIFF
--- a/configs/platforms/fedora-30-x86_64.rb
+++ b/configs/platforms/fedora-30-x86_64.rb
@@ -1,3 +1,0 @@
-platform "fedora-30-x86_64" do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/fedora-31-x86_64.rb
+++ b/configs/platforms/fedora-31-x86_64.rb
@@ -1,3 +1,0 @@
-platform "fedora-31-x86_64" do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,3 +1,0 @@
-platform "osx-10.14-x86_64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
This removes the platform configs for fedora 30, fedora 31, and osx
10.14.