### PR TITLE
(RE-13380) Set Apple notarization to false.

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -36,3 +36,4 @@ swix_staging_server: 'weth.delivery.puppetlabs.net'
 msi_staging_server: 'weth.delivery.puppetlabs.net'
 apt_signing_server: 'weth.delivery.puppetlabs.net'
 yum_staging_server: 'weth.delivery.puppetlabs.net'
+notarize_osx: FALSE


### PR DESCRIPTION
This will skip Apple Notarization for pdk. Notarization fails due to
fsevents gem (which is built with an old SDK, causing notarization to fail).
If this issue is fixed, Apple notarization may be possible in the future.