### PR TITLE
(MAINT) Bump json_pure_r27

### DIFF
--- a/configs/components/rubygem-json_pure_r27.rb
+++ b/configs/components/rubygem-json_pure_r27.rb
@@ -9,6 +9,6 @@ component "rubygem-json_pure_r27" do |pkg, settings, platform|
   end
 
   pkg.install do
-    "#{settings[:additional_rubies]['2.7.5'][:gem_install]} json_pure-#{pkg.get_version}.gem"
+    "#{settings[:additional_rubies]['2.7.6'][:gem_install]} json_pure-#{pkg.get_version}.gem"
   end
 end


### PR DESCRIPTION
This PR bumps the ruby version used for this component to 2.7.6.

It would appear that a dependancy was bumped in [this commit](https://github.com/puppetlabs/puppet-runtime/compare/202204120...202204121). Since this happened, the pdk-vanagon builds have been failing.

I've tested a [build](https://jenkins-platform.delivery.puppetlabs.net/view/PDK/job/platform_pdk_pdk-van-init_main/126/) from the associated branch and it passed.

Hopefully this is the fix.