### PR TITLE
(MAINT) Bump build dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.22')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.99.76')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.26.2')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.106.2')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
 gem 'csv', '3.1.5' if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.5.0')


### PR DESCRIPTION
This commit bumps the following gems:

    * vanagon
    * packaging

This is to ensure that we are inline with the latest versions available.