### PR TITLE
(MAINT) Revert version bumps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.26.2')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.106.2')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.22.0')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '>= 0.99.76')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
 gem 'csv', '3.1.5' if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.5.0')


### PR DESCRIPTION
Bumping the vanagon and packaging gems caused some unwanted side effects. 

This commit PR those changes.

We will revisit this in the after the next PDK release is complete.