### PR TITLE
(CONT-413) Reset pdk rubygem version

### DIFF
--- a/configs/components/pdk-templates.json
+++ b/configs/components/pdk-templates.json
@@ -1,5 +1,5 @@
 {
-  "ref": "7f9e1899737c0e3c13323f74bcec279e3ce70a8f",
+  "ref": "",
   "url": "https://github.com/puppetlabs/pdk-templates",
-  "version": "unknown"
+  "version": "2.5.0"
 }

--- a/configs/components/rubygem-pdk.json
+++ b/configs/components/rubygem-pdk.json
@@ -1,5 +1,5 @@
 {
-  "ref": "2ac1d4759ff1d3dcf6216bdc4697c2f3be9c581e",
-  "version": "2.6.0-pre",
+  "ref": "",
+  "version": "2.5.0",
   "url": "https://github.com/puppetlabs/pdk"
 }


### PR DESCRIPTION
To prepare for the next PDK patch release, this PR sets component versions back to 2.5.0