### PR TITLE
(CONT-413) Bump additional ruby version

### DIFF
--- a/configs/components/rubygem-json_pure_r27.rb
+++ b/configs/components/rubygem-json_pure_r27.rb
@@ -9,6 +9,6 @@ component "rubygem-json_pure_r27" do |pkg, settings, platform|
   end
 
   pkg.install do
-    "#{settings[:additional_rubies]['2.7.6'][:gem_install]} json_pure-#{pkg.get_version}.gem"
+    "#{settings[:additional_rubies]['2.7.7'][:gem_install]} json_pure-#{pkg.get_version}.gem"
   end
 end


### PR DESCRIPTION
Ruby version 2.7.6 had a CVE reported last year. As a result references in the puppet-runtime project were bumped to 2.7.7.

For this compoent we hard code the additional_rubies hash key. Prior to this change it was set to 2.7.6 which was causing build failures.

This change updates the key to 2.7.7 so that the look up will work as expected.