### PR TITLE
(CONT-513) Add Ubuntu 22.04 platform file

### DIFF
--- a/configs/platforms/ubuntu22.04-amd64.rb
+++ b/configs/platforms/ubuntu22.04-amd64.rb
@@ -1,0 +1,4 @@
+platform "ubuntu-22.04-amd64" do |plat|
+    plat.inherit_from_default
+  end
+


### PR DESCRIPTION
Prior to this commit, Ubuntu 22.04 was not supported by pdk. This commit adds the Ubuntu 22.04 platform file.