### PR TITLE
Temporarily remove RHEL9 

### DIFF
--- a/configs/platforms/el-9-x86_64.rb
+++ b/configs/platforms/el-9-x86_64.rb
@@ -1,4 +1,0 @@
-platform "el-9-x86_64" do |plat|
-    plat.inherit_from_default
-  end
-


### PR DESCRIPTION
Temporarily removing RHEL9 platform to avoid noise until other issues are sorted with it.