### PR TITLE
(CONT-698) Remove OSX 10.15 support

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,3 +1,0 @@
-platform "osx-10.15-x86_64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
OSX 10.15 support has been removed from pdk's ci-job-configs. This commit removes it from pdk-vanagon platforms for completeness.