### PR TITLE
(CONT-717) Remove byebyg

### DIFF
--- a/configs/components/pdk-templates.rb
+++ b/configs/components/pdk-templates.rb
@@ -84,12 +84,6 @@ component "pdk-templates" do |pkg, settings, platform|
     # inside the project cachedir.
     build_commands << "pushd #{mod_name} && #{gem_env.join(' ')} #{settings[:host_bundle]} install && popd"
 
-    unless platform.is_windows?
-      settings[:byebug_version][settings[:ruby_api]].each do |byebug_version|
-        build_commands << "#{gem_env.join(' ')} #{settings[:host_gem]} install --no-document byebug:#{byebug_version}"
-      end
-    end
-
     # Install bundler into the gem cache
     build_commands << "#{gem_env.join(' ')} #{settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler][:version]}.gem"
 
@@ -141,12 +135,6 @@ component "pdk-templates" do |pkg, settings, platform|
 
       # Install all the deps into the package cachedir.
       build_commands << "pushd #{local_mod_name} && #{local_gem_env.join(' ')} #{local_settings[:host_bundle]} install && popd"
-
-      unless platform.is_windows?
-        settings[:byebug_version][local_settings[:ruby_api]].each do |byebug_version|
-          build_commands << "#{local_gem_env.join(' ')} #{local_settings[:host_gem]} install --no-document byebug:#{byebug_version}"
-        end
-      end
 
       # Install bundler itself into the gem cache for this ruby
       build_commands << "#{local_gem_env.join(' ')} #{local_settings[:host_gem]} install --no-document --local --bindir /tmp ../bundler-#{settings[:bundler][:version]}.gem"

--- a/configs/components/puppet-versions.rb
+++ b/configs/components/puppet-versions.rb
@@ -147,23 +147,6 @@ component 'puppet-versions' do |pkg, settings, platform|
       }
 
       pdk_ruby_versions.each do |rubyapi|
-        settings[:byebug_version][rubyapi].each do |byebug_version|
-          build_commands << gem_install.call(
-            rubyapi,
-            'byebug',
-            byebug_version,
-            '--',
-            "--with-ruby-include=#{File.join(ruby_dirs[rubyapi], 'include', "ruby-#{rubyapi}")}",
-            "--with-ruby-lib=#{File.join(ruby_dirs[rubyapi], 'lib')}",
-          )
-
-          # Byebug 9.x requires special treatment b/c the cross compiled into a fat gem
-          if byebug_version.start_with?('9.')
-            byebug_libdir = File.join(puppet_cachedir, rubyapi, "gems", "byebug-#{byebug_version}-x64-mingw32", "lib", "byebug")
-            build_commands << "cp #{File.join(byebug_libdir, rubyapi.split('.')[0..1].join('.'), "byebug.so")} #{File.join(byebug_libdir, "byebug.so")}"
-          end
-        end
-
         # Add the remaining beaker dependencies that have been natively compiled
         # and repackaged.
         unless rubyapi =~ /^2\.7/

--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -58,11 +58,6 @@ project "pdk" do |proj|
     'sha256sum': '1ee53cdf61e728ad82c6dbff06cfcd8551d5422e88e86203f0e2dbe9ae999e09'
   })
 
-  proj.setting(:byebug_version, {
-    '2.1.0' => ['9.0.6'],
-    '2.7.0' => ['11.1.3'],
-  }.tap { |h| h.default = ['9.0.6', '11.1.3'] })
-
   proj.setting(:cachedir, File.join(proj.datadir, "cache"))
 
   if platform.is_windows?


### PR DESCRIPTION
Byebug is no longer a dependency of pdk or pdk-templates. This commit removes it from packaging.