### PR TITLE
(CONT-728) Update PowerShell wrapper

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -3,7 +3,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 $script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
 $script:DEVKIT_BASEDIR_SHORT = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
-$script:RUBY_DIR       = "$($script:DEVKIT_BASEDIR)\private\ruby\2.5.9"
+$script:RUBY_DIR = "$($script:DEVKIT_BASEDIR)\private\ruby\2.7.7"
 
 function pdk {
   if ($Host.Name -eq 'Windows PowerShell ISE Host') {


### PR DESCRIPTION
Prior to this change the PowerShell wrapper for PDK was pointing to Ruby 2.5.9.

This change updates the path to point to 2.7.7.