### PR TITLE
(CONT-760) Disable build ID generation

### DIFF
--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -84,7 +84,7 @@ project "pdk" do |proj|
 
     # Disable build-id generation since it's currently generating conflicts
     # with system libgcc and libstdc++
-    # proj.package_override("# Disable build-id generation to avoid conflicts\n%global _build_id_links none")
+    proj.package_override("# Disable build-id generation to avoid conflicts\n%global _build_id_links none")
     proj.package_override("# Disable the removal of la files, they are still required\n%global __brp_remove_la_files %{nil}")
     proj.package_override("# Disable check-rpaths since /opt/* is not a valid path\n%global __brp_check_rpaths %{nil}")
   end


### PR DESCRIPTION
Prior to this commit, the package build was configured to generate build ids.

It turns out that this still causes conflicts with other packages.

This commit ensures that we are no longer generating build ids/