### PR TITLE
(CONT-849) Update references to Ruby 2.7.7 to 2.7.8

### DIFF
--- a/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
+++ b/resources/files/windows/PuppetDevelopmentKit/PuppetDevelopmentKit.psm1
@@ -3,7 +3,7 @@ $fso = New-Object -ComObject Scripting.FileSystemObject
 $script:DEVKIT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\DevelopmentKit").RememberedInstallDir64
 # Windows API GetShortPathName requires inline C#, so use COM instead
 $script:DEVKIT_BASEDIR_SHORT = $fso.GetFolder($script:DEVKIT_BASEDIR).ShortPath
-$script:RUBY_DIR = "$($script:DEVKIT_BASEDIR)\private\ruby\2.7.7"
+$script:RUBY_DIR = "$($script:DEVKIT_BASEDIR)\private\ruby\2.7.8"
 
 function pdk {
   if ($Host.Name -eq 'Windows PowerShell ISE Host') {


### PR DESCRIPTION
Two CVEs have been reported in Ruby 2.7.7 resulting in references to 2.7.7 to bumped to 2.7.8 in pdk-runtime. Any references to 2.7.7 have been updated to 2.7.8 here in this commit.