### PR TITLE
(CONT-1054) Remove PowerShell Signing

### DIFF
--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -34,8 +34,6 @@ project 'pdk' do |proj|
       :ManualLink =>'https://puppet.com/docs/pdk/latest/pdk.html',
     })
 
-    module_directory = File.join(proj.datadir.sub(/^.*:\//, ''), 'PowerShell', 'Modules')
-    proj.extra_file_to_sign File.join(module_directory, 'PuppetDevelopmentKit', 'PuppetDevelopmentKit.psm1')
     proj.signing_hostname 'composer-deb-prod-2.delivery.puppetlabs.net'
     proj.signing_username 'jenkins'
     proj.signing_command 'source /usr/local/rvm/scripts/rvm; rvm use 2.7.5; /var/lib/jenkins/bin/extra_file_signer'


### PR DESCRIPTION
Now that the PowerShell loader has been removed, we no longer need to sign the file.