### PR TITLE
Support building pdk using a dev puppet-runtime build

### DIFF
--- a/configs/projects/pdk.rb
+++ b/configs/projects/pdk.rb
@@ -2,7 +2,12 @@ project 'pdk' do |proj|
   # Inherit a bunch of shared settings from pdk-runtime config
   runtime_config = JSON.parse(File.read(File.join(__dir__, '..', 'components', 'puppet-runtime.json')))
   proj.setting(:pdk_runtime_version, runtime_config['version'])
-  proj.inherit_settings 'pdk-runtime', 'https://github.com/puppetlabs/puppet-runtime', proj.pdk_runtime_version
+  proj.setting(:pdk_runtime_location, runtime_config['location'])
+  proj.setting(:pdk_runtime_basename, "pdk-runtime-#{runtime_config['version']}.#{platform.name}")
+  settings_uri = File.join(runtime_config['location'], "#{proj.settings[:pdk_runtime_basename]}.settings.yaml")
+  sha1sum_uri = "#{settings_uri}.sha1"
+  metadata_uri = File.join(runtime_config['location'], "#{proj.settings[:pdk_runtime_basename]}.json")
+  proj.inherit_yaml_settings(settings_uri, sha1sum_uri, metadata_uri: metadata_uri)
 
   proj.description 'Puppet Development Kit'
   proj.version_from_git


### PR DESCRIPTION
Previously, pdk required the pdk-runtime component to refer to a valid SHA in the https://github.com/puppetlabs/puppet-runtime repo which makes it difficult to test pdk-runtime changes before committing them.

This commit allows the pdk-runtime.json component to refer to an already built dev build that only exists locally such as:

    {
      "version":"202311141.4.g81059f6",
      "location":"file:///home/josh/work/puppet-runtime/output"
    }

Or a pdk-runtime build generated via Vanagon Generic Builder:

    {
      "version":"202308240.86.g81059f6",
      "location":"https://builds.delivery.puppetlabs.net/puppet-runtime/81059f6336c6b8f5f77ab9a3700eb0b2b58d5bcc/artifacts/"
    }

Where the pdk-runtime is relative to the 'location':

    ${location}/pdk-runtime-${version}.windows-2019-x64.tar.gz

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
