### PR TITLE
(CAT-1769) Cleanup legacy platforms

### DIFF
--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,3 +1,0 @@
-platform 'debian-9-amd64' do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -1,3 +1,0 @@
-platform 'el-6-x86_64' do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
Prior to this commit, we believed that support for Debian 9 and EL 6 was still active within the PDK. This is not the case, and as such, we are free to clean this code.
