### PR TITLE
(CAT1788) Add Mac OSX 13 support

### DIFF
--- a/configs/platforms/osx-13-arm64.rb
+++ b/configs/platforms/osx-13-arm64.rb
@@ -1,0 +1,3 @@
+platform 'osx-13-arm64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/osx-13-x86_64.rb
+++ b/configs/platforms/osx-13-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'osx-13-x86_64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
## Summary
Add support for Mac OSX 13 to the PDK.
Platform image for the arm64 version is being included but it may not be immediately added to the builds.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
