### PR TITLE
(CAT-1875) Add build targets for additional OS Architecture support

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'el-8-aarch64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'el-9-aarch64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,0 +1,3 @@
+platform 'osx-11-arm64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,0 +1,3 @@
+platform 'osx-12-arm64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/ubuntu-18.04-aarch64.rb
+++ b/configs/platforms/ubuntu-18.04-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'ubuntu-18.04-aarch64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/ubuntu-20.04-aarch64.rb
+++ b/configs/platforms/ubuntu-20.04-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'ubuntu-20.04-aarch64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
## Summary
Adding additional build targets to expand Architecture support.

## Checklist
- [x] Manually verified.
