### PR TITLE
(CAT-1944) Fedora 40 support

### DIFF
--- a/configs/platforms/fedora-40-x86_64.rb
+++ b/configs/platforms/fedora-40-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'fedora-40-x86_64' do |plat|
+    plat.inherit_from_default
+end


### PR DESCRIPTION
Prior to this commit, Fedora 40 was not a supported platform in PDK. This commit adds the necessary infrastructure to start building Fedora 40 in Jenkins.

