### PR TITLE
(CAT-1786) Remove Fedora <= 36 platforms

### DIFF
--- a/configs/platforms/fedora-32-x86_64.rb
+++ b/configs/platforms/fedora-32-x86_64.rb
@@ -1,3 +1,0 @@
-platform 'fedora-32-x86_64' do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/fedora-34-x86_64.rb
+++ b/configs/platforms/fedora-34-x86_64.rb
@@ -1,3 +1,0 @@
-platform 'fedora-34-x86_64' do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/fedora-36-x86_64.rb
+++ b/configs/platforms/fedora-36-x86_64.rb
@@ -1,3 +1,0 @@
-platform 'fedora-36-x86_64' do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
Prior to this commit, we decided to remove Fedora 36 from PDK support. This commit aims to reflect that decision. In addition, we are also cleaning up previous Fedora platforms that are no longer supported.
