### PR TITLE
(CAT-2005) - Update ubuntu-24.04-aarch config to include default values

### DIFF
--- a/configs/platforms/ubuntu-24.04-aarch64.rb
+++ b/configs/platforms/ubuntu-24.04-aarch64.rb
@@ -1,3 +1,14 @@
-platform 'ubuntu-24.04-aarch64' do |plat|
-  plat.inherit_from_default
+# this is needed as jenkins is using PDK vanagon 0.48.0 which doesn't have ubuntu-24.04-aarch64.rb
+# once Jenkins is using Vanagon version  0.49.0 or 0.50.0 we can revert this back
+
+platform "ubuntu-24.04-aarch64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "noble"
+
+  packages = %w(build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake)
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-2404-arm64"
 end


### PR DESCRIPTION
## Summary
This PR is needed as the PDK pipeline is not detecting the latest PDK vanagon build version with the default for ubuntu-24.04-aarch64.

This should be updated to call to default when possible 

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
