### PR TITLE
(CAT-2162) Remove support for SLES 12

### DIFF
--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,3 +1,0 @@
-platform 'sles-12-x86_64' do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
## Summary
Due to conflicts between a newer version of GIT required to resolve a lvl9 security vulnerability and SLES 12 it looks as if we will be unable to support it, as such given that General support for it has already ended we will be dropping it from the PDK

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
