### PR TITLE
(maint) Support Amazon 2023

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.48.0')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.118')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 2.0')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 2.0')
 
 # csv > 3.1.5 requires 'stringio' which the latest version of requires Ruby >= 2.5.0
 gem 'csv', '3.1.5' if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.5.0')

--- a/configs/platforms/amazon-2023-x86_64.rb
+++ b/configs/platforms/amazon-2023-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'amazon-2023-x86_64' do |plat|
+  plat.inherit_from_default
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -13,7 +13,7 @@ foss_platforms:
   - windows-2012-x64
 gpg_name: 'info@puppetlabs.com'
 deb_targets: 'trusty-amd64 xenial-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-11-x86_64 sles-12-x86_64'
+rpm_targets: 'amazon-2023-x86_64 el-6-x86_64 el-7-x86_64 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"


### PR DESCRIPTION
These are the changes that I _think_ are required to support Amazon 2023. Not sure if they are. There is a requisite step of building the runtime before I can manually test that. See the PR in the runtime project.