### PR TITLE
(CAT-2247) Remove support for Puppet 7 and Ruby 2.7

### DIFF
--- a/configs/components/gem-prune.rb
+++ b/configs/components/gem-prune.rb
@@ -17,7 +17,7 @@ component 'gem-prune' do |pkg, settings, platform|
       gem_bins[local_settings[:ruby_api]] = local_settings[:host_gem]
     end
 
-    pdk_ruby_versions = ['2.7.0', '3.2.0']
+    pdk_ruby_versions = ['3.2.0']
 
     pdk_ruby_versions.map do |rubyapi|
       gem_paths = [

--- a/configs/components/puppet-versions.rb
+++ b/configs/components/puppet-versions.rb
@@ -34,7 +34,6 @@ component 'puppet-versions' do |pkg, settings, platform|
   def ruby_for_puppet(version)
     # TODO: calculate this based on settings
     ruby_mappings = {
-      '2.7.0' => Gem::Requirement.create(['~> 7.0']),
       '3.2.0' => Gem::Requirement.create(['~> 8.0'])
     }
 
@@ -68,9 +67,9 @@ component 'puppet-versions' do |pkg, settings, platform|
     end
 
     latest_puppet8 = latest_puppet_gem('~>8.0')
-    latest_puppet7 = latest_puppet_gem('~>7.0')
+    # latest_puppet7 = latest_puppet_gem('~>7.0')
 
-    latest_puppets = [latest_puppet8, latest_puppet7].compact
+    latest_puppets = [latest_puppet8].compact
     puppet_rubyapi_versions = Hash[latest_puppets.collect { |pupver| [pupver.version, ruby_for_puppet(pupver)] }]
     pdk_ruby_versions = puppet_rubyapi_versions.values.uniq
 


### PR DESCRIPTION
## Summary
- Set ruby version for Puppet 8 from 3.2.0 to 3.1.0

## Linked PRs
- https://github.com/puppetlabs/pdk/pull/1443
- https://github.com/puppetlabs/puppet-runtime-private/pull/33

## Checklist
- [x] Manually verified.
